### PR TITLE
Add backend API routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# hostex-chat
+# Hostex Chat
+
+This project integrates Hostex conversations with ChatGPT, offering a web-based interface to view chats and send AI-assisted replies. The frontend lives in the `frontend/` directory and exposes several API routes for backend functionality.
+
+## Getting Started
+
+1. Change into the `frontend` folder and install dependencies:
+   ```bash
+   cd frontend
+   npm install
+   ```
+2. Copy `.env.example` to `.env` and set your Hostex and OpenAI keys.
+3. Run the development server:
+   ```bash
+   npm run dev
+   ```
+
+## API Routes
+
+- `GET /api/conversations` – fetches Hostex conversations from the last 7 days.
+- `GET /api/conversations/:id/replies` – list stored ChatGPT replies for a conversation.
+- `POST /api/conversations/:id/replies` – generate a new reply using ChatGPT and store it.
+- `POST /api/conversations/:id/send` – send a stored reply via the Hostex API.
+
+Configure `HOSTEX_API_BASE` in the `.env` file if your Hostex endpoint differs from the default `https://openapi.hostex.com`.

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,3 @@
+HOSTEX_API_TOKEN=your-hostex-token
+HOSTEX_API_BASE=https://openapi.hostex.com
+OPENAI_API_KEY=your-openai-key

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.next
+.env
+db.json

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,17 @@
+# Hostex Chat Frontend
+
+This directory contains a Next.js project that provides the web UI for Hostex Chat. It uses TypeScript and Tailwind CSS.
+
+## Development
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+
+2. Start the dev server:
+   ```bash
+   npm run dev
+   ```
+
+Environment variables can be configured in a `.env` file based on `.env.example`.

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    appDir: true
+  }
+};
+
+module.exports = nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "hostex-chat-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.1.4",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "5.4.5",
+    "@types/react": "18.2.21",
+    "@types/node": "20.11.19",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.1.4"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/src/app/api/conversations/[id]/replies/route.ts
+++ b/frontend/src/app/api/conversations/[id]/replies/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { addReply, listReplies } from '@/lib/db';
+
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  const replies = await listReplies(params.id);
+  return NextResponse.json({ replies });
+}
+
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  const { messages, model = 'gpt-3.5-turbo' } = await req.json();
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json({ error: 'OPENAI_API_KEY not configured' }, { status: 500 });
+  }
+
+  const res = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({ model, messages }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    return NextResponse.json({ error: text }, { status: res.status });
+  }
+
+  const data = await res.json();
+  const content = data.choices?.[0]?.message?.content || '';
+
+  const reply = await addReply({ conversationId: params.id, text: content, model });
+  return NextResponse.json({ reply });
+}

--- a/frontend/src/app/api/conversations/[id]/send/route.ts
+++ b/frontend/src/app/api/conversations/[id]/send/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { listReplies } from '@/lib/db';
+
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  const { replyId } = await req.json();
+  const token = process.env.HOSTEX_API_TOKEN;
+  const baseUrl = process.env.HOSTEX_API_BASE || 'https://openapi.hostex.com';
+
+  if (!token) {
+    return NextResponse.json({ error: 'HOSTEX_API_TOKEN not configured' }, { status: 500 });
+  }
+
+  const replies = await listReplies(params.id);
+  const reply = replies.find((r) => r.id === replyId);
+
+  if (!reply) {
+    return NextResponse.json({ error: 'Reply not found' }, { status: 404 });
+  }
+
+  const res = await fetch(`${baseUrl}/send-message`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ conversation_id: params.id, content: reply.text }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    return NextResponse.json({ error: text }, { status: res.status });
+  }
+
+  return NextResponse.json({ status: 'sent' });
+}

--- a/frontend/src/app/api/conversations/route.ts
+++ b/frontend/src/app/api/conversations/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  const token = process.env.HOSTEX_API_TOKEN;
+  const baseUrl = process.env.HOSTEX_API_BASE || 'https://openapi.hostex.com';
+
+  if (!token) {
+    return NextResponse.json({ error: 'HOSTEX_API_TOKEN not configured' }, { status: 500 });
+  }
+
+  const end = new Date();
+  const start = new Date(end.getTime() - 7 * 24 * 60 * 60 * 1000);
+
+  const params = new URLSearchParams({
+    start_time: start.toISOString(),
+    end_time: end.toISOString(),
+  });
+
+  try {
+    const res = await fetch(`${baseUrl}/conversations?${params.toString()}`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!res.ok) {
+      const text = await res.text();
+      return NextResponse.json({ error: text }, { status: res.status });
+    }
+
+    const data = await res.json();
+    return NextResponse.json(data);
+  } catch (err: any) {
+    return NextResponse.json({ error: err.message }, { status: 500 });
+  }
+}

--- a/frontend/src/app/api/hello/route.ts
+++ b/frontend/src/app/api/hello/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  return NextResponse.json({ message: 'Hello from API' });
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,0 +1,10 @@
+import '@/styles/globals.css';
+import { ReactNode } from 'react';
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface Conversation {
+  id: string;
+  [key: string]: any;
+}
+
+export default function Home() {
+  const [conversations, setConversations] = useState<Conversation[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch("/api/conversations")
+      .then((res) => res.json())
+      .then((data) => {
+        if (data.error) {
+          setError(data.error);
+        } else {
+          const list = data.conversations || data.items || data;
+          setConversations(Array.isArray(list) ? list : []);
+        }
+      })
+      .catch((err) => setError(err.message));
+  }, []);
+
+  return (
+    <main className="min-h-screen p-4">
+      <h1 className="mb-4 text-2xl font-bold">Hostex Chat</h1>
+      {error && <p className="text-red-600">{error}</p>}
+      <ul className="space-y-2">
+        {conversations.map((conv) => (
+          <li key={conv.id} className="rounded border p-2">
+            <pre className="whitespace-pre-wrap text-sm">
+              {JSON.stringify(conv, null, 2)}
+            </pre>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/frontend/src/lib/db.ts
+++ b/frontend/src/lib/db.ts
@@ -1,0 +1,46 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+export interface Reply {
+  id: string;
+  conversationId: string;
+  text: string;
+  model: string;
+  createdAt: string;
+}
+
+interface DB {
+  replies: Reply[];
+}
+
+const DB_PATH = path.join(process.cwd(), 'db.json');
+
+async function readDB(): Promise<DB> {
+  try {
+    const data = await fs.readFile(DB_PATH, 'utf8');
+    return JSON.parse(data) as DB;
+  } catch {
+    return { replies: [] };
+  }
+}
+
+async function writeDB(db: DB) {
+  await fs.writeFile(DB_PATH, JSON.stringify(db, null, 2));
+}
+
+export async function addReply(reply: Omit<Reply, 'id' | 'createdAt'>): Promise<Reply> {
+  const db = await readDB();
+  const newReply: Reply = {
+    id: crypto.randomUUID(),
+    createdAt: new Date().toISOString(),
+    ...reply,
+  };
+  db.replies.push(newReply);
+  await writeDB(db);
+  return newReply;
+}
+
+export async function listReplies(conversationId: string): Promise<Reply[]> {
+  const db = await readDB();
+  return db.replies.filter((r) => r.conversationId === conversationId);
+}

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,10 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './src/**/*.{js,ts,jsx,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- implement simple JSON-based database for storing AI replies
- add API routes to generate ChatGPT replies and send them via Hostex
- document new endpoints in README
- ignore the local db file in version control

## Testing
- `node -v`
- `npm -v`
- `npm run lint` *(fails: next not installed)*


------
https://chatgpt.com/codex/tasks/task_e_685cc3d9a1c88333b26a1503a93739cc