### PR TITLE
Add conversation reply management UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hostex Chat
 
-This project integrates Hostex conversations with ChatGPT, offering a web-based interface to view chats and send AI-assisted replies. The frontend lives in the `frontend/` directory and exposes several API routes for backend functionality. From the conversation list you can click a chat to view its full details.
+This project integrates Hostex conversations with ChatGPT, offering a web-based interface to view chats and send AI-assisted replies. The frontend lives in the `frontend/` directory and exposes several API routes for backend functionality. From the conversation list you can click a chat to view its full details. The detail page now lets you generate ChatGPT replies and send any stored reply back to Hostex.
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary
- show conversation replies in the detail view
- allow generating a new reply by posting a prompt
- enable sending any stored reply through the API
- document the new features in README

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d10bf636c83338ee38278a1ea2e5a