### PR TITLE
Add conversation viewer UI

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,16 +1,26 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import Link from "next/link";
 
 interface Conversation {
   id: string;
   [key: string]: any;
 }
 
+interface ConversationDetail {
+  id: string;
+  messages?: { content: string; [key: string]: any }[];
+  [key: string]: any;
+}
+
 export default function Home() {
   const [conversations, setConversations] = useState<Conversation[]>([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [detail, setDetail] = useState<ConversationDetail | null>(null);
+  const [message, setMessage] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const [loadingDetail, setLoadingDetail] = useState(false);
+  const [sending, setSending] = useState(false);
 
   useEffect(() => {
     fetch("/api/conversations")
@@ -26,22 +36,109 @@ export default function Home() {
       .catch((err) => setError(err.message));
   }, []);
 
+  useEffect(() => {
+    if (!selectedId) return;
+    setLoadingDetail(true);
+    fetch(`/api/conversations/${selectedId}`)
+      .then((res) => res.json())
+      .then((data) => {
+        if (data.error) {
+          setError(data.error);
+          setDetail(null);
+        } else {
+          setDetail(data);
+        }
+      })
+      .catch((err) => setError(err.message))
+      .finally(() => setLoadingDetail(false));
+  }, [selectedId]);
+
+  async function sendMessage() {
+    if (!selectedId || !message.trim()) return;
+    setSending(true);
+    try {
+      const res = await fetch(`/api/conversations/${selectedId}/send`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ content: message }),
+      });
+      const data = await res.json();
+      if (!res.ok || data.error) {
+        setError(data.error || "Failed to send");
+      } else {
+        setMessage("");
+        // refresh detail after sending
+        setSelectedId(selectedId);
+      }
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setSending(false);
+    }
+  }
+
   return (
-    <main className="min-h-screen p-4">
-      <h1 className="mb-4 text-2xl font-bold">Hostex Chat</h1>
-      {error && <p className="text-red-600">{error}</p>}
-      <ul className="space-y-2">
-        {conversations.map((conv) => (
-          <li key={conv.id} className="rounded border p-2 hover:bg-gray-50">
-            <Link href={`/conversations/${conv.id}`}
-              className="block">
-              <pre className="whitespace-pre-wrap text-sm">
-                {JSON.stringify(conv, null, 2)}
-              </pre>
-            </Link>
-          </li>
-        ))}
-      </ul>
+    <main className="min-h-screen flex divide-x">
+      <aside className="w-1/3 max-w-sm p-4 space-y-2 overflow-y-auto">
+        <h1 className="mb-4 text-2xl font-bold">Hostex Chat</h1>
+        {error && <p className="text-red-600">{error}</p>}
+        <ul className="space-y-2">
+          {conversations.map((conv) => (
+            <li key={conv.id}>
+              <button
+                className={`w-full text-left rounded border p-2 hover:bg-gray-50 ${
+                  selectedId === conv.id ? "bg-gray-100" : ""
+                }`}
+                onClick={() => setSelectedId(conv.id)}
+              >
+                {conv.subject || conv.id}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </aside>
+      <section className="flex-1 p-4 flex flex-col">
+        {selectedId ? (
+          loadingDetail ? (
+            <p>Loading...</p>
+          ) : detail ? (
+            <>
+              <div className="flex-1 overflow-y-auto space-y-2 mb-4">
+                {detail.messages ? (
+                  detail.messages.map((m, idx) => (
+                    <div key={idx} className="rounded border p-2">
+                      <p className="whitespace-pre-wrap text-sm">{m.content}</p>
+                    </div>
+                  ))
+                ) : (
+                  <pre className="whitespace-pre-wrap text-sm">
+                    {JSON.stringify(detail, null, 2)}
+                  </pre>
+                )}
+              </div>
+              <div className="flex items-end space-x-2">
+                <input
+                  className="flex-1 rounded border p-2"
+                  placeholder="Type a reply..."
+                  value={message}
+                  onChange={(e) => setMessage(e.target.value)}
+                />
+                <button
+                  onClick={sendMessage}
+                  disabled={sending}
+                  className="rounded bg-blue-600 px-3 py-1 text-white"
+                >
+                  Send
+                </button>
+              </div>
+            </>
+          ) : (
+            <p>No detail</p>
+          )
+        ) : (
+          <p className="text-gray-500">Select a conversation</p>
+        )}
+      </section>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- show conversations in a list
- display selected conversation details on the right
- allow typing a reply and send the message

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685d67e96c7c8333bdaca1acea29b0c9