### PR TITLE
Fix chat order

### DIFF
--- a/frontend/src/app/conversations/[id]/page.tsx
+++ b/frontend/src/app/conversations/[id]/page.tsx
@@ -22,6 +22,15 @@ export default function ConversationPage({ params }: { params: { id: string } })
   const [sending, setSending] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
 
+  function orderMessages(messages?: Message[]) {
+    if (!Array.isArray(messages)) return messages;
+    return [...messages].sort((a, b) => {
+      const ta = new Date(a.created_at ?? 0).getTime();
+      const tb = new Date(b.created_at ?? 0).getTime();
+      return ta - tb;
+    });
+  }
+
   async function fetchDetail() {
     try {
       const res = await fetch(`/api/conversations/${params.id}`);
@@ -29,7 +38,8 @@ export default function ConversationPage({ params }: { params: { id: string } })
       if (!res.ok || data.error) {
         setError(data.error || "Failed to load");
       } else {
-        setDetail(data.data ?? data);
+        const d = data.data ?? data;
+        setDetail({ ...d, messages: orderMessages(d.messages) });
       }
     } catch (err: any) {
       setError(err.message);

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -43,6 +43,15 @@ export default function Home() {
       .catch((err) => setError(err.message));
   }, []);
 
+  function orderMessages(messages?: { created_at?: string }[]) {
+    if (!Array.isArray(messages)) return messages;
+    return [...messages].sort((a, b) => {
+      const ta = new Date(a.created_at ?? 0).getTime();
+      const tb = new Date(b.created_at ?? 0).getTime();
+      return ta - tb;
+    });
+  }
+
   async function fetchDetail(id: string) {
     setLoadingDetail(true);
     try {
@@ -52,7 +61,8 @@ export default function Home() {
         setError(data.error || "Failed to load");
         setDetail(null);
       } else {
-        setDetail(data.data ?? data);
+        const d = data.data ?? data;
+        setDetail({ ...d, messages: orderMessages(d.messages) });
       }
     } catch (err: any) {
       setError(err.message);


### PR DESCRIPTION
## Summary
- ensure conversation details are sorted chronologically

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685d75f96a488333a93a20c43c87144b