### PR TITLE
Add Hostex webhook route with event storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ This project integrates Hostex conversations with ChatGPT, offering a web-based 
 - `GET /api/conversations/:id/replies` – list stored ChatGPT replies for a conversation.
 - `POST /api/conversations/:id/replies` – generate a new reply using ChatGPT and store it.
 - `POST /api/conversations/:id/send` – send a stored reply via the Hostex API.
+- `POST /api/webhook/hostex` – receive Hostex webhook events verified with
+  `HOSTEX_API_TOKEN` and persist new message events in `db.json`.
 
 Generated replies can be edited before sending on the conversation detail page.
 

--- a/frontend/src/app/api/webhook/hostex/route.ts
+++ b/frontend/src/app/api/webhook/hostex/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from 'next/server';
+import crypto from 'crypto';
+import { addWebhookEvent } from '@/lib/db';
+
+export async function POST(req: NextRequest) {
+  const secret = process.env.HOSTEX_API_TOKEN;
+  if (!secret) {
+    return NextResponse.json(
+      { error: 'HOSTEX_API_TOKEN not configured' },
+      { status: 500 }
+    );
+  }
+
+  const signature = req.headers.get('hostex-signature');
+  const rawBody = await req.text();
+  const expected = crypto.createHmac('sha256', secret).update(rawBody).digest('hex');
+
+  if (signature !== expected) {
+    return NextResponse.json({ error: 'Invalid signature' }, { status: 401 });
+  }
+
+  let payload: any;
+  try {
+    payload = JSON.parse(rawBody);
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const type = payload.type || payload.event;
+  if (type === 'message.created' || type === 'message_created') {
+    const conversationId =
+      payload.conversation_id || payload.data?.conversation_id || payload.data?.conversationId;
+    if (conversationId) {
+      await addWebhookEvent({ type, conversationId, payload });
+    }
+  }
+
+  return NextResponse.json({ status: 'ok' });
+}


### PR DESCRIPTION
## Summary
- add `HOSTEX_API_TOKEN` verification for webhook
- support `message_created` events
- remove redundant webhook secret from `.env.example`
- document new webhook endpoint
- improve db parsing for events

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685d8081c0308333babee27c273583b7