### PR TITLE
Add server-sent events for webhook updates

### DIFF
--- a/frontend/src/app/api/events/route.ts
+++ b/frontend/src/app/api/events/route.ts
@@ -1,0 +1,25 @@
+import { addClient, removeClient } from '@/lib/events';
+
+export function GET(req: Request) {
+  const { readable, writable } = new TransformStream();
+  const writer = writable.getWriter();
+  addClient(writer);
+
+  const keepAlive = setInterval(() => {
+    writer.write(new TextEncoder().encode(':keep-alive\n\n')).catch(() => {});
+  }, 15000);
+
+  req.signal.addEventListener('abort', () => {
+    clearInterval(keepAlive);
+    removeClient(writer);
+    writer.close();
+  });
+
+  return new Response(readable, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+    },
+  });
+}

--- a/frontend/src/app/api/webhook/hostex/route.ts
+++ b/frontend/src/app/api/webhook/hostex/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import crypto from 'crypto';
 import { addWebhookEvent } from '@/lib/db';
+import { broadcast } from '@/lib/events';
 
 export async function POST(req: NextRequest) {
   const secret = process.env.HOSTEX_API_TOKEN;
@@ -31,7 +32,8 @@ export async function POST(req: NextRequest) {
     const conversationId =
       payload.conversation_id || payload.data?.conversation_id || payload.data?.conversationId;
     if (conversationId) {
-      await addWebhookEvent({ type, conversationId, payload });
+      const event = await addWebhookEvent({ type, conversationId, payload });
+      broadcast({ conversationId, message: event.payload?.data || event.payload });
     }
   }
 

--- a/frontend/src/lib/events.ts
+++ b/frontend/src/lib/events.ts
@@ -1,0 +1,20 @@
+const encoder = new TextEncoder();
+const clients = new Set<WritableStreamDefaultWriter>();
+
+export function addClient(writer: WritableStreamDefaultWriter) {
+  clients.add(writer);
+}
+
+export function removeClient(writer: WritableStreamDefaultWriter) {
+  clients.delete(writer);
+}
+
+export function broadcast(data: any) {
+  const payload = `data: ${JSON.stringify(data)}\n\n`;
+  const encoded = encoder.encode(payload);
+  for (const writer of Array.from(clients)) {
+    writer.write(encoded).catch(() => {
+      clients.delete(writer);
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add lib for SSE client tracking and broadcasting
- implement `/api/events` SSE route
- broadcast new webhook events to SSE clients

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685d84545a348333a02af0808a4981f9