### PR TITLE
Fix Hostex send message endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,36 @@ Generated replies can be edited before sending on the conversation detail page.
 
 Configure `HOSTEX_API_BASE` in the `.env` file if your Hostex endpoint differs from the default `https://api.hostex.io/v3`.
 
+## Example: Sending a Message
+
+Hostex expects new messages to be posted to the `/conversations/:id` endpoint
+with a JSON body containing a single `message` field. Below is a minimal
+example using `fetch`:
+
+```javascript
+const url = 'https://api.hostex.io/v3/conversations/YOUR_CONVERSATION_ID';
+const options = {
+  method: 'POST',
+  headers: {
+    accept: 'application/json',
+    'content-type': 'application/json',
+    // Replace with your token or read from an environment variable
+    'Hostex-Access-Token': process.env.HOSTEX_API_TOKEN,
+  },
+  body: JSON.stringify({
+    message: 'Hello from Hostex Chat!',
+  }),
+};
+
+fetch(url, options)
+  .then((res) => res.json())
+  .then((json) => console.log(json))
+  .catch((err) => console.error(err));
+```
+
+Ensure the `Hostex-Access-Token` header is set to a valid API token and that the
+conversation ID exists. Use the `message` field when posting new messages.
+
 ## Webhook Setup
 
 To keep conversations up to date you can configure a webhook in Hostex so that

--- a/frontend/src/app/api/conversations/[id]/send/route.ts
+++ b/frontend/src/app/api/conversations/[id]/send/route.ts
@@ -20,7 +20,7 @@ export async function POST(
     return NextResponse.json({ error: 'Reply not found' }, { status: 404 });
   }
 
-  const res = await fetch(`${baseUrl}/send-message`, {
+  const res = await fetch(`${baseUrl}/conversations/${params.id}`, {
     method: 'POST',
     headers: {
       'Hostex-Access-Token': token,
@@ -28,8 +28,7 @@ export async function POST(
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
-      conversation_id: params.id,
-      content: content ?? reply!.text,
+      message: content ?? reply!.text,
     }),
   });
 


### PR DESCRIPTION
## Summary
- fix Hostex message send endpoint to POST /conversations/:id
- document correct endpoint and request body in README

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685d88ca7f248333871a8acd0e7565f1