### PR TITLE
Improve webhook logging and dark mode

### DIFF
--- a/frontend/src/app/api/webhook/hostex/route.ts
+++ b/frontend/src/app/api/webhook/hostex/route.ts
@@ -16,7 +16,10 @@ export async function POST(req: NextRequest) {
   const rawBody = await req.text();
   const expected = crypto.createHmac('sha256', secret).update(rawBody).digest('hex');
 
+  console.log('Webhook received', { signature, expected, body: rawBody });
+
   if (signature !== expected) {
+    console.warn('Invalid webhook signature');
     return NextResponse.json({ error: 'Invalid signature' }, { status: 401 });
   }
 
@@ -34,6 +37,7 @@ export async function POST(req: NextRequest) {
     if (conversationId) {
       const event = await addWebhookEvent({ type, conversationId, payload });
       broadcast({ conversationId, message: event.payload?.data || event.payload });
+      console.log('Webhook event processed', { type, conversationId });
     }
   }
 

--- a/frontend/src/app/conversations/[id]/page.tsx
+++ b/frontend/src/app/conversations/[id]/page.tsx
@@ -35,6 +35,7 @@ export default function ConversationPage({ params }: { params: { id: string } })
     if (prompt) {
       payload.unshift({ role: 'system', content: prompt });
     }
+    console.log('Generating reply for conversation', params.id, 'with', msgs.length, 'messages');
     setGenerating(true);
     try {
       const res = await fetch(`/api/conversations/${params.id}/replies`, {
@@ -77,6 +78,7 @@ export default function ConversationPage({ params }: { params: { id: string } })
         if (ordered) {
           generateReply(ordered);
         }
+        console.log('Loaded conversation detail', { id: params.id, messages: ordered?.length });
       }
     } catch (err: any) {
       setError(err.message);
@@ -99,6 +101,7 @@ export default function ConversationPage({ params }: { params: { id: string } })
         const id = data.conversationId || data.conversation_id;
         if (id === params.id) {
           fetchDetail();
+          console.log('SSE update for conversation', id, data);
         }
       } catch {
         // ignore JSON parse errors
@@ -125,6 +128,7 @@ export default function ConversationPage({ params }: { params: { id: string } })
       } else {
         setMessage("");
         await fetchDetail();
+        console.log('Message sent', { id: params.id, content: message });
       }
     } catch (err: any) {
       setError(err.message);
@@ -155,8 +159,8 @@ export default function ConversationPage({ params }: { params: { id: string } })
                 <div
                   className={`max-w-xs rounded p-2 text-sm whitespace-pre-wrap ${
                     m.sender_role === "host"
-                      ? "bg-blue-500 text-white"
-                      : "bg-gray-200"
+                      ? "bg-blue-500 text-white dark:bg-blue-600"
+                      : "bg-gray-200 dark:bg-gray-700 dark:text-gray-100"
                   }`}
                 >
                   {m.content}
@@ -171,10 +175,10 @@ export default function ConversationPage({ params }: { params: { id: string } })
         )}
         <div ref={messagesEndRef} />
       </div>
-      <div className="p-4 border-t fixed bottom-0 left-0 right-0 bg-white">
+      <div className="p-4 border-t fixed bottom-0 left-0 right-0 bg-white dark:bg-gray-900">
         <div className="flex items-end space-x-2">
           <input
-            className="flex-1 rounded border p-2"
+            className="flex-1 rounded border p-2 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-100"
             placeholder="Type a reply..."
             value={message}
             onChange={(e) => setMessage(e.target.value)}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -69,6 +69,7 @@ export default function Home() {
         if (ordered) {
           generateReply(ordered);
         }
+        console.log('Loaded conversation detail', { id, messages: ordered?.length });
       }
     } catch (err: any) {
       setError(err.message);
@@ -96,6 +97,7 @@ export default function Home() {
         if (!id) return;
         if (id === selectedId) {
           fetchDetail(id);
+          console.log('SSE update for conversation', id, data);
         } else {
           setUpdates((u) => ({ ...u, [id]: true }));
         }
@@ -120,6 +122,7 @@ export default function Home() {
     if (prompt) {
       payload.unshift({ role: "system", content: prompt });
     }
+    console.log('Generating reply for conversation', selectedId, 'with', msgs.length, 'messages');
     setGenerating(true);
     try {
       const res = await fetch(`/api/conversations/${selectedId}/replies`, {
@@ -155,6 +158,7 @@ export default function Home() {
       } else {
         setMessage("");
         await fetchDetail(selectedId);
+        console.log('Message sent', { id: selectedId, content: message });
       }
     } catch (err: any) {
       setError(err.message);
@@ -175,8 +179,8 @@ export default function Home() {
           {conversations.map((conv) => (
             <li key={conv.id}>
               <button
-                className={`w-full text-left rounded border p-2 hover:bg-gray-50 ${
-                  selectedId === conv.id ? "bg-gray-100" : ""
+                className={`w-full text-left rounded border p-2 hover:bg-gray-50 dark:hover:bg-gray-800 ${
+                  selectedId === conv.id ? "bg-gray-100 dark:bg-gray-800" : "dark:bg-gray-700"
                 } ${updates[conv.id] ? "border-blue-500" : ""}`}
                 onClick={() => {
                   setSelectedId(conv.id);
@@ -218,8 +222,8 @@ export default function Home() {
                       <div
                         className={`max-w-md rounded-lg px-3 py-2 text-sm whitespace-pre-wrap ${
                           m.sender_role === "host"
-                            ? "bg-blue-500 text-white"
-                            : "bg-gray-200"
+                            ? "bg-blue-500 text-white dark:bg-blue-600"
+                            : "bg-gray-200 dark:bg-gray-700 dark:text-gray-100"
                         }`}
                       >
                         {m.content}
@@ -233,10 +237,10 @@ export default function Home() {
                 )}
                 <div ref={messagesEndRef} />
               </div>
-              <div className="p-4 border-t">
+              <div className="p-4 border-t dark:bg-gray-900">
                 <div className="flex items-end space-x-2">
                   <input
-                    className="flex-1 rounded border p-2"
+                    className="flex-1 rounded border p-2 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-100"
                     placeholder="Type a reply..."
                     value={message}
                     onChange={(e) => setMessage(e.target.value)}


### PR DESCRIPTION
## Summary
- log detailed info when webhook hits the server
- log message sending and SSE updates on the client
- adjust message bubbles and inputs for better dark mode display

## Testing
- `npm run lint`
- `npm run build` *(fails: Argument of type '{ created_at?: string; }[]' is not assignable to parameter of type '{ sender_role?: string; content: string; }[]'.)*

------
https://chatgpt.com/codex/tasks/task_e_685d8e3922388333b0061cf1347d0581