### PR TITLE
Switch to SQLite storage and add debug logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This project integrates Hostex conversations with ChatGPT, offering a web-based 
 - `POST /api/conversations/:id/replies` – generate a new reply using ChatGPT and store it.
 - `POST /api/conversations/:id/send` – send a stored reply via the Hostex API.
 - `POST /api/webhook/hostex` – receive Hostex webhook events verified with
-  `HOSTEX_API_TOKEN` and persist new message events in `db.json`.
+  `HOSTEX_API_TOKEN` and persist new message events in `db.sqlite`.
 
 Generated replies can be edited before sending on the conversation detail page.
 
@@ -73,5 +73,5 @@ dashboard with the following settings:
 3. **Events** – subscribe to the `message.created` event to capture new incoming
    messages.
 
-Webhook payloads are stored in `db.json` and broadcast to connected clients via
+Webhook payloads are stored in `db.sqlite` and broadcast to connected clients via
 Server‑Sent Events.

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,4 +1,4 @@
 node_modules
 .next
 .env
-db.json
+db.sqlite


### PR DESCRIPTION
## Summary
- overhaul db.ts to use a SQLite file instead of a JSON file
- output executed SQL statements when running in development mode
- ignore `db.sqlite` and document new storage path in README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685d91b54fcc8333a71c12168c0af892