### PR TITLE
Improve Hostex Chat UI with reusable components

### DIFF
--- a/frontend/src/app/conversations/[id]/page.tsx
+++ b/frontend/src/app/conversations/[id]/page.tsx
@@ -1,17 +1,15 @@
 "use client";
 import { useEffect, useRef, useState } from "react";
-import Link from "next/link";
+import Header from "@/components/Header";
+import MessageBubble, { Message } from "@/components/MessageBubble";
 
-interface Message {
+interface ChatMessage extends Message {
   id: string;
-  sender_role?: string;
-  content: string;
-  created_at?: string;
 }
 
 interface ConversationDetail {
   id: string;
-  messages?: Message[];
+  messages?: ChatMessage[];
   [key: string]: any;
 }
 
@@ -23,10 +21,6 @@ export default function ConversationPage({ params }: { params: { id: string } })
   const [generating, setGenerating] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
 
-  function formatTime(ts?: string) {
-    if (!ts) return '';
-    return new Date(ts).toLocaleString();
-  }
 
   async function generateReply(msgs: Message[]) {
     const settings = JSON.parse(localStorage.getItem('settings') || '{}');
@@ -143,87 +137,69 @@ export default function ConversationPage({ params }: { params: { id: string } })
   }
 
   return (
-    <main className="flex h-screen">
-      <div className="flex-1 flex flex-col">
-        <div className="p-4 border-b flex justify-between items-center">
-          <Link href="/" className="text-blue-600 underline">
-            Back
-          </Link>
-          <a href="/settings" className="text-blue-600 underline text-sm">Settings</a>
-        </div>
-        <div className="flex-1 overflow-y-auto p-4 space-y-2 pb-24">
-          {error && <p className="text-red-600">{error}</p>}
-          {detail ? (
-            detail.messages?.length ? (
-              detail.messages.map((m) => (
-                <div
-                key={m.id}
-                className={`flex ${
-                  m.sender_role === "host" ? "justify-end" : "justify-start"
-                }`}
+    <div className="flex-1 flex flex-col">
+      <Header backHref="/" />
+      <main className="flex flex-1">
+        <div className="flex-1 flex flex-col">
+          <div className="flex-1 overflow-y-auto p-4 space-y-2 pb-24">
+            {error && <p className="text-red-600">{error}</p>}
+            {detail ? (
+              detail.messages?.length ? (
+                detail.messages.map((m) => (
+                  <MessageBubble key={m.id} message={m} />
+                ))
+              ) : (
+                <p>No messages</p>
+              )
+            ) : (
+              <p>Loading...</p>
+            )}
+            <div ref={messagesEndRef} />
+          </div>
+          <div className="p-4 border-t dark:bg-gray-900 sticky bottom-0">
+            <div className="flex items-end space-x-2">
+              <input
+                className="flex-1 rounded border p-2 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-100"
+                placeholder="Type a reply..."
+                value={message}
+                onChange={(e) => setMessage(e.target.value)}
+              />
+              <button
+                onClick={() => detail?.messages && generateReply(detail.messages)}
+                disabled={generating}
+                className="rounded bg-gray-600 px-3 py-1 text-white"
               >
-                <div
-                  className={`max-w-xs rounded p-2 text-sm whitespace-pre-wrap ${
-                    m.sender_role === "host"
-                      ? "bg-blue-500 text-white dark:bg-blue-600"
-                      : "bg-gray-200 dark:bg-gray-700 dark:text-gray-100"
-                  }`}
-                >
-                  {m.content}
-                </div>
-              </div>
-            ))
-          ) : (
-            <p>No messages</p>
-          )
-        ) : (
-          <p>Loading...</p>
-        )}
-        <div ref={messagesEndRef} />
-        </div>
-        <div className="p-4 border-t dark:bg-gray-900 sticky bottom-0">
-          <div className="flex items-end space-x-2">
-          <input
-            className="flex-1 rounded border p-2 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-100"
-            placeholder="Type a reply..."
-            value={message}
-            onChange={(e) => setMessage(e.target.value)}
-          />
-          <button
-            onClick={() => detail?.messages && generateReply(detail.messages)}
-            disabled={generating}
-            className="rounded bg-gray-600 px-3 py-1 text-white"
-          >
-            {generating ? '...' : 'AI'}
-          </button>
-          <button
-            onClick={send}
-            disabled={sending}
-            className="rounded bg-blue-600 px-3 py-1 text-white"
-          >
-            Send
-          </button>
+                {generating ? '...' : 'AI'}
+              </button>
+              <button
+                onClick={send}
+                disabled={sending}
+                className="rounded bg-blue-600 px-3 py-1 text-white"
+              >
+                Send
+              </button>
+            </div>
           </div>
         </div>
-      </div>
-      {detail && (
-        <aside className="hidden w-60 shrink-0 border-l p-4 space-y-4 overflow-y-auto md:block">
-          {detail.customer && (
-            <div>
-              <h2 className="font-semibold mb-1">Customer</h2>
-              <div className="text-sm">{detail.customer.name || detail.customer.full_name}</div>
-              <pre className="whitespace-pre-wrap text-xs mt-2">{JSON.stringify(detail.customer, null, 2)}</pre>
-            </div>
-          )}
-          {detail.property && (
-            <div>
-              <h2 className="font-semibold mb-1">Property</h2>
-              <div className="text-sm">{detail.property.name || detail.property.title}</div>
-              <pre className="whitespace-pre-wrap text-xs mt-2">{JSON.stringify(detail.property, null, 2)}</pre>
-            </div>
-          )}
-        </aside>
-      )}
-    </main>
+        {detail && (
+          <aside className="hidden w-60 shrink-0 border-l p-4 space-y-4 overflow-y-auto md:block">
+            {detail.customer && (
+              <div>
+                <h2 className="font-semibold mb-1">Customer</h2>
+                <div className="text-sm">{detail.customer.name || detail.customer.full_name}</div>
+                <pre className="whitespace-pre-wrap text-xs mt-2">{JSON.stringify(detail.customer, null, 2)}</pre>
+              </div>
+            )}
+            {detail.property && (
+              <div>
+                <h2 className="font-semibold mb-1">Property</h2>
+                <div className="text-sm">{detail.property.name || detail.property.title}</div>
+                <pre className="whitespace-pre-wrap text-xs mt-2">{JSON.stringify(detail.property, null, 2)}</pre>
+              </div>
+            )}
+          </aside>
+        )}
+      </main>
+    </div>
   );
 }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -24,8 +24,8 @@ export default function RootLayout({ children }: { children: ReactNode }) {
     }
   }, []);
   return (
-    <html lang="en">
-      <body className="bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+    <html lang="en" className="h-full">
+      <body className="min-h-screen bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100 flex flex-col">
         {children}
       </body>
     </html>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,6 +1,9 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import Header from "@/components/Header";
+import ConversationItem from "@/components/ConversationItem";
+import MessageBubble, { Message } from "@/components/MessageBubble";
 
 interface Conversation {
   id: string;
@@ -9,7 +12,7 @@ interface Conversation {
 
 interface ConversationDetail {
   id: string;
-  messages?: { content: string; [key: string]: any }[];
+  messages?: Message[];
   [key: string]: any;
 }
 
@@ -19,60 +22,16 @@ export default function Home() {
   const [detail, setDetail] = useState<ConversationDetail | null>(null);
   const [message, setMessage] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const [loadingList, setLoadingList] = useState(false);
   const [loadingDetail, setLoadingDetail] = useState(false);
   const [sending, setSending] = useState(false);
   const [generating, setGenerating] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
   const [updates, setUpdates] = useState<Record<string, boolean>>({});
 
-  function getCustomerName(conv: any) {
-    return (
-      conv.customer?.name ||
-      conv.customer_name ||
-      conv.name ||
-      conv.subject ||
-      conv.id
-    );
-  }
-
-  function getPropertyTitle(conv: any) {
-    return (
-      conv.property_title ||
-      conv.property?.title ||
-      conv.property?.name ||
-      ''
-    );
-  }
-
-  function getStayDates(conv: any) {
-    const inDate = conv.check_in_date || conv.checkInDate;
-    const outDate = conv.check_out_date || conv.checkOutDate;
-    return inDate && outDate ? `${inDate} - ${outDate}` : '';
-  }
-
-  function getChannel(conv: any) {
-    return conv.channel_type || conv.channelType || '';
-  }
-
-  function getLastMessage(conv: any) {
-    if (Array.isArray(conv.messages) && conv.messages.length) {
-      return conv.messages[conv.messages.length - 1];
-    }
-    return conv.last_message || conv.lastMessage || null;
-  }
-
-  function preview(content?: string) {
-    if (!content) return '';
-    const line = content.split('\n')[0];
-    return line.length > 50 ? line.slice(0, 50) + '...' : line;
-  }
-
-  function formatTime(ts?: string) {
-    if (!ts) return '';
-    return new Date(ts).toLocaleString();
-  }
 
   useEffect(() => {
+    setLoadingList(true);
     fetch("/api/conversations")
       .then((res) => res.json())
       .then((data) => {
@@ -89,7 +48,8 @@ export default function Home() {
           setConversations(Array.isArray(list) ? list : []);
         }
       })
-      .catch((err) => setError(err.message));
+      .catch((err) => setError(err.message))
+      .finally(() => setLoadingList(false));
   }, []);
 
   function orderMessages(messages?: { created_at?: string }[]) {
@@ -215,154 +175,110 @@ export default function Home() {
   }
 
   return (
-    <main className="h-screen flex divide-x">
-      <aside className="w-72 flex flex-col border-r">
-        <div className="p-4 border-b flex justify-between items-center">
-          <h1 className="text-2xl font-bold">Hostex Chat</h1>
-          <a href="/settings" className="text-blue-600 underline text-sm">Settings</a>
-        </div>
-        {error && <p className="p-4 text-red-600">{error}</p>}
-        <ul className="flex-1 overflow-y-auto p-4 space-y-2">
-          {conversations.map((conv) => (
-            <li key={conv.id}>
-              <button
-                className={`w-full text-left rounded border p-2 hover:bg-gray-50 dark:hover:bg-gray-800 ${
-                  selectedId === conv.id ? "bg-gray-100 dark:bg-gray-800" : "dark:bg-gray-700"
-                } ${updates[conv.id] ? "border-blue-500" : ""}`}
-                onClick={() => {
-                  setSelectedId(conv.id);
-                  setUpdates((u) => {
-                    const { [conv.id]: _removed, ...rest } = u;
-                    return rest;
-                  });
-                }}
-              >
-                <div className="flex justify-between">
-                  <div className="flex-1 pr-2 overflow-hidden">
-                    <div className="font-medium truncate">
-                      {getCustomerName(conv)}
-                    </div>
-                    {getPropertyTitle(conv) && (
-                      <div className="text-xs text-gray-500 truncate">
-                        {getPropertyTitle(conv)}
-                      </div>
-                    )}
-                    {(getStayDates(conv) || getChannel(conv)) && (
-                      <div className="text-xs text-gray-500 truncate">
-                        {getStayDates(conv)}{getChannel(conv) ? ` • ${getChannel(conv)}` : ''}
-                      </div>
-                    )}
-                    <div className="text-xs text-gray-500 truncate">
-                      {preview(getLastMessage(conv)?.content)}
-                    </div>
-                  </div>
-                  <div className="text-right pl-2">
-                    <div className="text-xs text-gray-500 whitespace-nowrap">
-                      {formatTime(
-                        getLastMessage(conv)?.created_at ||
-                          getLastMessage(conv)?.createdAt
-                      )}
-                    </div>
-                    {updates[conv.id] && (
-                      <span className="ml-2 mt-1 inline-block h-2 w-2 rounded-full bg-blue-500" />
-                    )}
-                  </div>
-                </div>
-              </button>
-            </li>
-          ))}
-        </ul>
-      </aside>
-      <section className="flex-1 flex">
-        <div className="flex-1 flex flex-col">
-          {selectedId ? (
-            loadingDetail ? (
-              <p className="p-4">Loading...</p>
-            ) : detail ? (
-              <>
-              <div className="p-4 border-b font-semibold">
-                {detail.subject || detail.id}
-              </div>
-              <div className="flex-1 overflow-y-auto p-4 space-y-2">
-                {detail.messages ? (
-                  detail.messages.map((m, idx) => (
-                    <div
-                      key={idx}
-                      className={`flex ${
-                        m.sender_role === "host" ? "justify-end" : "justify-start"
-                      }`}
-                    >
-                      <div
-                        className={`max-w-md rounded-lg px-3 py-2 text-sm whitespace-pre-wrap ${
-                          m.sender_role === "host"
-                            ? "bg-blue-500 text-white dark:bg-blue-600"
-                            : "bg-gray-200 dark:bg-gray-700 dark:text-gray-100"
-                        }`}
-                      >
-                        {m.content}
-                      </div>
-                    </div>
-                  ))
-                ) : (
-                  <pre className="whitespace-pre-wrap text-sm">
-                    {JSON.stringify(detail, null, 2)}
-                  </pre>
-                )}
-                <div ref={messagesEndRef} />
-              </div>
-              <div className="p-4 border-t dark:bg-gray-900 sticky bottom-0">
-                <div className="flex items-end space-x-2">
-                  <input
-                    className="flex-1 rounded border p-2 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-100"
-                    placeholder="Type a reply..."
-                    value={message}
-                    onChange={(e) => setMessage(e.target.value)}
-                  />
-                  <button
-                    onClick={() => detail?.messages && generateReply(detail.messages)}
-                    disabled={generating}
-                    className="rounded bg-gray-600 px-3 py-1 text-white"
-                  >
-                    {generating ? '...' : 'AI'}
-                  </button>
-                  <button
-                    onClick={sendMessage}
-                    disabled={sending}
-                    className="rounded bg-blue-600 px-3 py-1 text-white"
-                  >
-                    Send
-                  </button>
-                </div>
-              </div>
-            </>
+    <div className="flex-1 flex flex-col">
+      <Header />
+      <main className="flex flex-1 divide-x">
+        <aside className="w-72 flex flex-col border-r">
+          {loadingList ? (
+            <p className="p-4">Loading...</p>
+          ) : error ? (
+            <p className="p-4 text-red-600">{error}</p>
           ) : (
-            <p className="p-4">No detail</p>
-          )
-        ) : (
-          <div className="flex-1 flex items-center justify-center text-gray-500">
-            Select a conversation
+            <ul className="flex-1 overflow-y-auto p-4 space-y-2">
+              {conversations.map((conv) => (
+                <ConversationItem
+                  key={conv.id}
+                  conv={conv}
+                  selected={selectedId === conv.id}
+                  hasUpdate={updates[conv.id]}
+                  onClick={() => {
+                    setSelectedId(conv.id);
+                    setUpdates((u) => {
+                      const { [conv.id]: _removed, ...rest } = u;
+                      return rest;
+                    });
+                  }}
+                />
+              ))}
+            </ul>
+          )}
+        </aside>
+        <section className="flex-1 flex">
+          <div className="flex-1 flex flex-col">
+            {selectedId ? (
+              loadingDetail ? (
+                <p className="p-4">Loading...</p>
+              ) : detail ? (
+                <>
+                  <div className="p-4 border-b font-semibold">
+                    {detail.subject || detail.id}
+                  </div>
+                  <div className="flex-1 overflow-y-auto p-4 space-y-2">
+                    {detail.messages ? (
+                      detail.messages.map((m, idx) => (
+                        <MessageBubble key={idx} message={m} />
+                      ))
+                    ) : (
+                      <pre className="whitespace-pre-wrap text-sm">
+                        {JSON.stringify(detail, null, 2)}
+                      </pre>
+                    )}
+                    <div ref={messagesEndRef} />
+                  </div>
+                  <div className="p-4 border-t dark:bg-gray-900 sticky bottom-0">
+                    <div className="flex items-end space-x-2">
+                      <input
+                        className="flex-1 rounded border p-2 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-100"
+                        placeholder="Type a reply..."
+                        value={message}
+                        onChange={(e) => setMessage(e.target.value)}
+                      />
+                      <button
+                        onClick={() => detail?.messages && generateReply(detail.messages)}
+                        disabled={generating}
+                        className="rounded bg-gray-600 px-3 py-1 text-white"
+                      >
+                        {generating ? '...' : 'AI'}
+                      </button>
+                      <button
+                        onClick={sendMessage}
+                        disabled={sending}
+                        className="rounded bg-blue-600 px-3 py-1 text-white"
+                      >
+                        Send
+                      </button>
+                    </div>
+                  </div>
+                </>
+              ) : (
+                <p className="p-4">No detail</p>
+              )
+            ) : (
+              <div className="flex-1 flex items-center justify-center text-gray-500">
+                Select a conversation
+              </div>
+            )}
           </div>
-        )}
-        </div>
-        {detail && (
-          <aside className="hidden w-60 shrink-0 border-l p-4 space-y-4 overflow-y-auto md:block">
-            {detail.customer && (
-              <div>
-                <h2 className="font-semibold mb-1">Customer</h2>
-                <div className="text-sm">{detail.customer.name || detail.customer.full_name}</div>
-                <pre className="whitespace-pre-wrap text-xs mt-2">{JSON.stringify(detail.customer, null, 2)}</pre>
-              </div>
-            )}
-            {detail.property && (
-              <div>
-                <h2 className="font-semibold mb-1">Property</h2>
-                <div className="text-sm">{detail.property.name || detail.property.title}</div>
-                <pre className="whitespace-pre-wrap text-xs mt-2">{JSON.stringify(detail.property, null, 2)}</pre>
-              </div>
-            )}
-          </aside>
-        )}
-      </section>
-    </main>
+          {detail && (
+            <aside className="hidden w-60 shrink-0 border-l p-4 space-y-4 overflow-y-auto md:block">
+              {detail.customer && (
+                <div>
+                  <h2 className="font-semibold mb-1">Customer</h2>
+                  <div className="text-sm">{detail.customer.name || detail.customer.full_name}</div>
+                  <pre className="whitespace-pre-wrap text-xs mt-2">{JSON.stringify(detail.customer, null, 2)}</pre>
+                </div>
+              )}
+              {detail.property && (
+                <div>
+                  <h2 className="font-semibold mb-1">Property</h2>
+                  <div className="text-sm">{detail.property.name || detail.property.title}</div>
+                  <pre className="whitespace-pre-wrap text-xs mt-2">{JSON.stringify(detail.property, null, 2)}</pre>
+                </div>
+              )}
+            </aside>
+          )}
+        </section>
+      </main>
+    </div>
   );
 }

--- a/frontend/src/components/ConversationItem.tsx
+++ b/frontend/src/components/ConversationItem.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+interface Props {
+  conv: any;
+  selected?: boolean;
+  hasUpdate?: boolean;
+  onClick: () => void;
+}
+
+function getCustomerName(conv: any) {
+  return (
+    conv.customer?.name ||
+    conv.customer_name ||
+    conv.name ||
+    conv.subject ||
+    conv.id
+  );
+}
+
+function getPropertyTitle(conv: any) {
+  return (
+    conv.property_title ||
+    conv.property?.title ||
+    conv.property?.name ||
+    ''
+  );
+}
+
+function getStayDates(conv: any) {
+  const inDate = conv.check_in_date || conv.checkInDate;
+  const outDate = conv.check_out_date || conv.checkOutDate;
+  return inDate && outDate ? `${inDate} - ${outDate}` : '';
+}
+
+function getChannel(conv: any) {
+  return conv.channel_type || conv.channelType || '';
+}
+
+function getLastMessage(conv: any) {
+  if (Array.isArray(conv.messages) && conv.messages.length) {
+    return conv.messages[conv.messages.length - 1];
+  }
+  return conv.last_message || conv.lastMessage || null;
+}
+
+function preview(content?: string) {
+  if (!content) return '';
+  const line = content.split('\n')[0];
+  return line.length > 50 ? line.slice(0, 50) + '...' : line;
+}
+
+function formatTime(ts?: string) {
+  if (!ts) return '';
+  return new Date(ts).toLocaleString();
+}
+
+export default function ConversationItem({ conv, selected, hasUpdate, onClick }: Props) {
+  return (
+    <li>
+      <button
+        className={`w-full text-left rounded border p-2 hover:bg-gray-50 dark:hover:bg-gray-800 ${
+          selected ? 'bg-gray-100 dark:bg-gray-800' : 'dark:bg-gray-700'
+        } ${hasUpdate ? 'border-blue-500' : ''}`}
+        onClick={onClick}
+      >
+        <div className="flex justify-between">
+          <div className="flex-1 pr-2 overflow-hidden">
+            <div className="font-medium truncate">{getCustomerName(conv)}</div>
+            {getPropertyTitle(conv) && (
+              <div className="text-xs text-gray-500 truncate">
+                {getPropertyTitle(conv)}
+              </div>
+            )}
+            {(getStayDates(conv) || getChannel(conv)) && (
+              <div className="text-xs text-gray-500 truncate">
+                {getStayDates(conv)}{getChannel(conv) ? ` • ${getChannel(conv)}` : ''}
+              </div>
+            )}
+            <div className="text-xs text-gray-500 truncate">
+              {preview(getLastMessage(conv)?.content)}
+            </div>
+          </div>
+          <div className="text-right pl-2">
+            <div className="text-xs text-gray-500 whitespace-nowrap">
+              {formatTime(
+                getLastMessage(conv)?.created_at ||
+                getLastMessage(conv)?.createdAt
+              )}
+            </div>
+            {hasUpdate && (
+              <span className="ml-2 mt-1 inline-block h-2 w-2 rounded-full bg-blue-500" />
+            )}
+          </div>
+        </div>
+      </button>
+    </li>
+  );
+}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,0 +1,20 @@
+'use client';
+import Link from 'next/link';
+
+export default function Header({ backHref }: { backHref?: string }) {
+  return (
+    <header className="border-b bg-white/80 dark:bg-gray-900/80 backdrop-blur p-4 flex justify-between items-center sticky top-0 z-10">
+      <div className="flex items-center space-x-4">
+        {backHref && (
+          <Link href={backHref} className="text-blue-600 hover:underline">
+            Back
+          </Link>
+        )}
+        <h1 className="text-xl font-bold">Hostex Chat</h1>
+      </div>
+      <Link href="/settings" className="text-blue-600 hover:underline">
+        Settings
+      </Link>
+    </header>
+  );
+}

--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+export interface Message {
+  sender_role?: string;
+  content: string;
+  created_at?: string;
+}
+
+export default function MessageBubble({ message }: { message: Message }) {
+  const isHost = message.sender_role === 'host';
+  return (
+    <div className={`flex ${isHost ? 'justify-end' : 'justify-start'}`}>
+      <div className={`max-w-md rounded-lg px-3 py-2 text-sm whitespace-pre-wrap ${isHost ? 'bg-blue-500 text-white dark:bg-blue-600' : 'bg-gray-200 dark:bg-gray-700 dark:text-gray-100'}`}>
+        {message.content}
+        {message.created_at && (
+          <div className="mt-1 text-xs opacity-70 text-right">
+            {new Date(message.created_at).toLocaleString()}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -1,3 +1,10 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap');
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  html {
+    font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif;
+  }
+}


### PR DESCRIPTION
## Summary
- add shared `Header`, `ConversationItem` and `MessageBubble` components
- refine global styles and layout
- modernize conversation list and detail pages

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685e41d574f88333922b3a9e8b17e502