### PR TITLE
Add shadcn-ui components

### DIFF
--- a/frontend/components.json
+++ b/frontend/components.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "default",
+  "rsc": false,
+  "tsx": true,
+  "tailwind": {
+    "config": "tailwind.config.js",
+    "css": "src/styles/globals.css",
+    "baseColor": "slate",
+    "cssVariables": true
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils"
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,10 @@
     "next": "14.1.4",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "better-sqlite3": "^9.4.1"
+    "better-sqlite3": "^9.4.1",
+    "@radix-ui/react-slot": "latest",
+    "class-variance-authority": "latest",
+    "tailwindcss-animate": "latest"
   },
   "devDependencies": {
     "typescript": "5.4.5",

--- a/frontend/shadcn-preset.js
+++ b/frontend/shadcn-preset.js
@@ -1,0 +1,11 @@
+module.exports = {
+  theme: {
+    extend: {
+      borderRadius: {
+        lg: 'var(--radius)',
+        md: 'calc(var(--radius) - 2px)',
+        sm: 'calc(var(--radius) - 4px)',
+      },
+    },
+  },
+}

--- a/frontend/src/app/conversations/[id]/page.tsx
+++ b/frontend/src/app/conversations/[id]/page.tsx
@@ -2,6 +2,8 @@
 import { useEffect, useRef, useState } from "react";
 import Header from "@/components/Header";
 import MessageBubble, { Message } from "@/components/MessageBubble";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 
 interface ChatMessage extends Message {
   id: string;
@@ -158,26 +160,22 @@ export default function ConversationPage({ params }: { params: { id: string } })
           </div>
           <div className="p-4 border-t dark:bg-gray-900 sticky bottom-0">
             <div className="flex items-end space-x-2">
-              <input
-                className="flex-1 rounded border p-2 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-100"
+              <Input
+                className="flex-1"
                 placeholder="Type a reply..."
                 value={message}
                 onChange={(e) => setMessage(e.target.value)}
               />
-              <button
+              <Button
                 onClick={() => detail?.messages && generateReply(detail.messages)}
                 disabled={generating}
-                className="rounded bg-gray-600 px-3 py-1 text-white"
+                variant="secondary"
               >
                 {generating ? '...' : 'AI'}
-              </button>
-              <button
-                onClick={send}
-                disabled={sending}
-                className="rounded bg-blue-600 px-3 py-1 text-white"
-              >
+              </Button>
+              <Button onClick={send} disabled={sending}>
                 Send
-              </button>
+              </Button>
             </div>
           </div>
         </div>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -4,6 +4,8 @@ import { useEffect, useRef, useState } from "react";
 import Header from "@/components/Header";
 import ConversationItem from "@/components/ConversationItem";
 import MessageBubble, { Message } from "@/components/MessageBubble";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 
 interface Conversation {
   id: string;
@@ -52,7 +54,7 @@ export default function Home() {
       .finally(() => setLoadingList(false));
   }, []);
 
-  function orderMessages(messages?: { created_at?: string }[]) {
+  function orderMessages(messages?: Message[]) {
     if (!Array.isArray(messages)) return messages;
     return [...messages].sort((a, b) => {
       const ta = new Date(a.created_at ?? 0).getTime();
@@ -227,26 +229,22 @@ export default function Home() {
                   </div>
                   <div className="p-4 border-t dark:bg-gray-900 sticky bottom-0">
                     <div className="flex items-end space-x-2">
-                      <input
-                        className="flex-1 rounded border p-2 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-100"
+                      <Input
+                        className="flex-1"
                         placeholder="Type a reply..."
                         value={message}
                         onChange={(e) => setMessage(e.target.value)}
                       />
-                      <button
+                      <Button
                         onClick={() => detail?.messages && generateReply(detail.messages)}
                         disabled={generating}
-                        className="rounded bg-gray-600 px-3 py-1 text-white"
+                        variant="secondary"
                       >
                         {generating ? '...' : 'AI'}
-                      </button>
-                      <button
-                        onClick={sendMessage}
-                        disabled={sending}
-                        className="rounded bg-blue-600 px-3 py-1 text-white"
-                      >
+                      </Button>
+                      <Button onClick={sendMessage} disabled={sending}>
                         Send
-                      </button>
+                      </Button>
                     </div>
                   </div>
                 </>

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -1,6 +1,9 @@
 "use client";
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 
 interface Model {
   id: string;
@@ -63,9 +66,9 @@ export default function Settings() {
       <div className="space-y-2">
         <label className="block">
           <span className="font-medium">OpenAI API Key</span>
-          <input
+          <Input
             type="password"
-            className="mt-1 w-full rounded border p-2"
+            className="mt-1 w-full"
             value={apiKey}
             onChange={(e) => setApiKey(e.target.value)}
           />
@@ -87,8 +90,8 @@ export default function Settings() {
         </label>
         <label className="block">
           <span className="font-medium">System Prompt</span>
-          <textarea
-            className="mt-1 w-full rounded border p-2"
+          <Textarea
+            className="mt-1 w-full"
             rows={3}
             value={prompt}
             onChange={(e) => setPrompt(e.target.value)}
@@ -106,12 +109,7 @@ export default function Settings() {
             <option value="system">System</option>
           </select>
         </label>
-        <button
-          onClick={save}
-          className="rounded bg-blue-600 px-3 py-1 text-white"
-        >
-          Save
-        </button>
+        <Button onClick={save}>Save</Button>
       </div>
     </main>
   );

--- a/frontend/src/components/ConversationItem.tsx
+++ b/frontend/src/components/ConversationItem.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { Button } from './ui/button'
 
 interface Props {
   conv: any;
@@ -57,11 +58,13 @@ function formatTime(ts?: string) {
 export default function ConversationItem({ conv, selected, hasUpdate, onClick }: Props) {
   return (
     <li>
-      <button
-        className={`w-full text-left rounded border p-2 hover:bg-gray-50 dark:hover:bg-gray-800 ${
+      <Button
+        className={`w-full text-left border p-2 hover:bg-gray-50 dark:hover:bg-gray-800 ${
           selected ? 'bg-gray-100 dark:bg-gray-800' : 'dark:bg-gray-700'
         } ${hasUpdate ? 'border-blue-500' : ''}`}
         onClick={onClick}
+        variant="secondary"
+        size="default"
       >
         <div className="flex justify-between">
           <div className="flex-1 pr-2 overflow-hidden">
@@ -92,7 +95,7 @@ export default function ConversationItem({ conv, selected, hasUpdate, onClick }:
             )}
           </div>
         </div>
-      </button>
+      </Button>
     </li>
   );
 }

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -1,0 +1,55 @@
+"use client"
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 ring-offset-background",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        outline: "border border-input hover:bg-accent hover:text-accent-foreground",
+        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-md px-8",
+        icon: "h-10 w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button"
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Button.displayName = "Button"
+
+export { Button, buttonVariants }

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -1,0 +1,26 @@
+"use client"
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+export interface InputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = "Input"
+
+export { Input }

--- a/frontend/src/components/ui/textarea.tsx
+++ b/frontend/src/components/ui/textarea.tsx
@@ -1,0 +1,25 @@
+"use client"
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+export interface TextareaProps
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <textarea
+        className={cn(
+          "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Textarea.displayName = "Textarea"
+
+export { Textarea }

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: (string | false | null | undefined)[]): string {
+  return classes.filter(Boolean).join(' ');
+}

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -4,6 +4,70 @@
 @tailwind utilities;
 
 @layer base {
+  :root {
+    --background: 0 0% 100%;
+    --foreground: 240 10% 3.9%;
+
+    --muted: 240 4.8% 95.9%;
+    --muted-foreground: 240 3.8% 46.1%;
+
+    --popover: 0 0% 100%;
+    --popover-foreground: 240 10% 3.9%;
+
+    --card: 0 0% 100%;
+    --card-foreground: 240 10% 3.9%;
+
+    --border: 240 5.9% 90%;
+    --input: 240 5.9% 90%;
+
+    --primary: 240 5.9% 10%;
+    --primary-foreground: 0 0% 98%;
+
+    --secondary: 240 4.8% 95.9%;
+    --secondary-foreground: 240 5.9% 10%;
+
+    --accent: 240 4.8% 95.9%;
+    --accent-foreground: 240 5.9% 10%;
+
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 0 0% 98%;
+
+    --ring: 240 5% 64.9%;
+
+    --radius: 0.5rem;
+  }
+
+  .dark {
+    --background: 240 10% 3.9%;
+    --foreground: 0 0% 98%;
+
+    --muted: 240 3.7% 15.9%;
+    --muted-foreground: 240 5.4% 63.9%;
+
+    --popover: 240 10% 3.9%;
+    --popover-foreground: 0 0% 98%;
+
+    --card: 240 10% 3.9%;
+    --card-foreground: 0 0% 98%;
+
+    --border: 240 3.7% 15.9%;
+    --input: 240 3.7% 15.9%;
+
+    --primary: 0 0% 98%;
+    --primary-foreground: 240 5.9% 10%;
+
+    --secondary: 240 3.7% 15.9%;
+    --secondary-foreground: 0 0% 98%;
+
+    --accent: 240 3.7% 15.9%;
+    --accent-foreground: 0 0% 98%;
+
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 0 0% 98%;
+
+    --ring: 240 4.9% 83.9%;
+  }
+
   html {
     font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif;
   }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,11 +1,23 @@
+const { fontFamily } = require('tailwindcss/defaultTheme')
+
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   darkMode: 'class',
-  content: [
-    './src/**/*.{js,ts,jsx,tsx}'
-  ],
+  content: ['./src/**/*.{js,ts,jsx,tsx}'],
+  presets: [require('./shadcn-preset.js')],
   theme: {
-    extend: {},
+    container: {
+      center: true,
+      padding: '2rem',
+      screens: {
+        '2xl': '1400px',
+      },
+    },
+    extend: {
+      fontFamily: {
+        sans: ['Inter', ...fontFamily.sans],
+      },
+    },
   },
-  plugins: [],
-};
+  plugins: [require('tailwindcss-animate')],
+}


### PR DESCRIPTION
## Summary
- initialize shadcn-ui config and presets
- add shadcn-inspired UI components
- update Tailwind config for presets and animations
- use new Button/Input/Textarea components in pages
- declare dependencies for shadcn-ui libraries
- switch to official shadcn implementations and add theme variables

## Testing
- `npm run build` *(fails: Module not found: Can't resolve '@radix-ui/react-slot')*

------
https://chatgpt.com/codex/tasks/task_e_685e4a9737b08333b410f4081a82f212