### PR TITLE
Add OpenAI log viewer in conversation page

### DIFF
--- a/frontend/src/app/api/conversations/[id]/openai-logs/route.ts
+++ b/frontend/src/app/api/conversations/[id]/openai-logs/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server'
+import { listOpenAILogs } from '@/lib/db'
+
+export async function GET(_req: Request, { params }: { params: { id: string } }) {
+  const logs = await listOpenAILogs(params.id)
+  return NextResponse.json({ logs })
+}

--- a/frontend/src/app/api/conversations/[id]/replies/route.ts
+++ b/frontend/src/app/api/conversations/[id]/replies/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { addReply, listReplies } from '@/lib/db';
+import { addReply, listReplies, addOpenAILog } from '@/lib/db';
 
 export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
   const replies = await listReplies(params.id);
@@ -12,6 +12,8 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
   if (!key) {
     return NextResponse.json({ error: 'OPENAI_API_KEY not configured' }, { status: 500 });
   }
+
+  await addOpenAILog({ conversationId: params.id, payload: { model, messages } });
 
   const res = await fetch('https://api.openai.com/v1/chat/completions', {
     method: 'POST',


### PR DESCRIPTION
## Summary
- record OpenAI request payloads in SQLite
- expose new API route to list OpenAI logs per conversation
- log OpenAI requests when generating replies
- show a log button in conversation detail page and render a modal with the logs

## Testing
- `npm run lint`
- `npm run build` *(fails: static page generation timeout)*

------
https://chatgpt.com/codex/tasks/task_e_685e5e456fa483339f35cd94d23f202e