### PR TITLE
Fix static generation timeouts by setting dynamic runtime

### DIFF
--- a/frontend/src/app/api/conversations/[id]/openai-logs/route.ts
+++ b/frontend/src/app/api/conversations/[id]/openai-logs/route.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from 'next/server'
 import { listOpenAILogs } from '@/lib/db'
 
+export const dynamic = 'force-dynamic'
+export const runtime = 'nodejs'
+
 export async function GET(_req: Request, { params }: { params: { id: string } }) {
   const logs = await listOpenAILogs(params.id)
   return NextResponse.json({ logs })

--- a/frontend/src/app/api/conversations/[id]/replies/route.ts
+++ b/frontend/src/app/api/conversations/[id]/replies/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { addReply, listReplies, addOpenAILog } from '@/lib/db';
 
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
 export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
   const replies = await listReplies(params.id);
   return NextResponse.json({ replies });

--- a/frontend/src/app/api/conversations/[id]/route.ts
+++ b/frontend/src/app/api/conversations/[id]/route.ts
@@ -1,5 +1,8 @@
 import { NextResponse } from 'next/server';
 
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
 export async function GET(
   _req: Request,
   { params }: { params: { id: string } }

--- a/frontend/src/app/api/conversations/[id]/send/route.ts
+++ b/frontend/src/app/api/conversations/[id]/send/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { listReplies } from '@/lib/db';
 
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
 export async function POST(
   req: NextRequest,
   { params }: { params: { id: string } }

--- a/frontend/src/app/api/conversations/route.ts
+++ b/frontend/src/app/api/conversations/route.ts
@@ -1,5 +1,8 @@
 import { NextResponse } from 'next/server';
 
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
 export async function GET() {
   const token = process.env.HOSTEX_API_TOKEN;
   const baseUrl = process.env.HOSTEX_API_BASE || 'https://api.hostex.io/v3';

--- a/frontend/src/app/api/events/route.ts
+++ b/frontend/src/app/api/events/route.ts
@@ -1,5 +1,8 @@
 import { addClient, removeClient } from '@/lib/events';
 
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
 export function GET(req: Request) {
   const { readable, writable } = new TransformStream();
   const writer = writable.getWriter();

--- a/frontend/src/app/api/hello/route.ts
+++ b/frontend/src/app/api/hello/route.ts
@@ -1,5 +1,8 @@
 import { NextResponse } from 'next/server';
 
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
 export async function GET() {
   return NextResponse.json({ message: 'Hello from API' });
 }

--- a/frontend/src/app/api/openai/models/route.ts
+++ b/frontend/src/app/api/openai/models/route.ts
@@ -1,5 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
 export async function POST(req: NextRequest) {
   const { apiKey } = await req.json();
   if (!apiKey) {

--- a/frontend/src/app/api/webhook/hostex/route.ts
+++ b/frontend/src/app/api/webhook/hostex/route.ts
@@ -3,6 +3,9 @@ import crypto from 'crypto';
 import { addWebhookEvent } from '@/lib/db';
 import { broadcast } from '@/lib/events';
 
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
 export async function POST(req: NextRequest) {
   const secret = process.env.HOSTEX_API_TOKEN;
   if (!secret) {


### PR DESCRIPTION
## Summary
- add `force-dynamic` config and runtime to all API routes

## Testing
- `pnpm run build`

------
https://chatgpt.com/codex/tasks/task_e_685e750fde408333a5de2be2e981344a