### PR TITLE
Add auto update to production setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,34 @@ dashboard with the following settings:
 
 Webhook payloads are stored in `db.sqlite` and broadcast to connected clients via
 Server‑Sent Events.
+
+## Production Deployment
+
+To run Hostex Chat on a public Ubuntu server you can use the helper script in
+`scripts/setup_production.sh`. It installs Node.js, Nginx and Certbot, builds the
+Next.js app and sets up a systemd service. Nginx is configured to proxy traffic
+on port 80/443 to the Node.js server running on port 3000. TLS certificates are
+issued automatically with Let's Encrypt and HTTP traffic is redirected to HTTPS
+so Cloudflare can safely connect over TLS. An additional timer checks the GitHub
+repository for updates, pulls the `main` branch, rebuilds and restarts the
+service when changes are detected.
+
+```bash
+sudo ./scripts/setup_production.sh
+```
+
+Edit the `DOMAIN` and `EMAIL` variables inside the script if you want to use a
+different hostname or certificate email address. After the script completes the
+application will be available over HTTPS.
+
+### Codex Environment
+
+For the Codex test environment you can install the minimal dependencies using
+`scripts/setup_codex.sh`:
+
+```bash
+./scripts/setup_codex.sh
+```
+
+This installs Node.js and the project dependencies so Codex can run the build or
+test commands.

--- a/scripts/setup_codex.sh
+++ b/scripts/setup_codex.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Setup dependencies for Codex testing environment
+set -euo pipefail
+
+apt-get update
+apt-get install -y nodejs npm
+cd frontend
+npm install

--- a/scripts/setup_production.sh
+++ b/scripts/setup_production.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Setup Hostex Chat for production on Ubuntu
+set -euo pipefail
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo "This script must be run as root" >&2
+  exit 1
+fi
+
+APP_DIR=/opt/hostex-chat
+REPO_URL="https://github.com/example/hostex-chat.git"
+NODE_VERSION=18
+DOMAIN="hostex-chat-c873d713.ox.ci"
+EMAIL="admin@example.com"
+
+# install system packages
+apt-get update
+apt-get install -y curl gnupg2 ca-certificates lsb-release nginx git
+
+# install Node.js LTS via nodesource
+curl -fsSL https://deb.nodesource.com/setup_$NODE_VERSION.x | bash -
+apt-get install -y nodejs
+
+# clone or update application code
+if [ ! -d "$APP_DIR/.git" ]; then
+  git clone "$REPO_URL" "$APP_DIR"
+else
+  cd "$APP_DIR"
+  git fetch origin
+  git checkout main
+  git pull --ff-only origin main
+fi
+cd "$APP_DIR/frontend"
+npm install
+npm run build
+
+# create update script to pull latest code and rebuild
+cat >/usr/local/bin/hostex-chat-update.sh <<'UPDATE'
+#!/usr/bin/env bash
+set -e
+APP_DIR=/opt/hostex-chat
+cd "$APP_DIR"
+git fetch origin
+LOCAL=$(git rev-parse @)
+REMOTE=$(git rev-parse origin/main)
+if [ "$LOCAL" != "$REMOTE" ]; then
+  git reset --hard origin/main
+  cd frontend
+  npm install
+  npm run build
+  systemctl restart hostex-chat.service
+fi
+UPDATE
+chmod +x /usr/local/bin/hostex-chat-update.sh
+
+# create systemd service
+cat >/etc/systemd/system/hostex-chat.service <<SERVICE
+[Unit]
+Description=Hostex Chat
+After=network.target
+
+[Service]
+Type=simple
+User=www-data
+WorkingDirectory=$APP_DIR/frontend
+ExecStart=/usr/bin/npm start
+Restart=always
+Environment=NODE_ENV=production
+
+[Install]
+WantedBy=multi-user.target
+SERVICE
+
+systemctl daemon-reload
+systemctl enable --now hostex-chat.service
+
+# create systemd unit to update the app periodically
+cat >/etc/systemd/system/hostex-chat-update.service <<UPDATE_SERVICE
+[Unit]
+Description=Update Hostex Chat from GitHub
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/hostex-chat-update.sh
+UPDATE_SERVICE
+
+cat >/etc/systemd/system/hostex-chat-update.timer <<UPDATE_TIMER
+[Unit]
+Description=Check Hostex Chat repository for updates
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=5min
+Unit=hostex-chat-update.service
+
+[Install]
+WantedBy=timers.target
+UPDATE_TIMER
+
+systemctl daemon-reload
+systemctl enable --now hostex-chat-update.timer
+
+# configure nginx
+cat >/etc/nginx/sites-available/hostex-chat <<NGINX
+server {
+    listen 80;
+    server_name $DOMAIN;
+
+    location / {
+        proxy_pass http://localhost:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+    }
+}
+NGINX
+
+ln -sf /etc/nginx/sites-available/hostex-chat /etc/nginx/sites-enabled/hostex-chat
+rm -f /etc/nginx/sites-enabled/default
+systemctl reload nginx
+
+# install certbot and obtain certificate
+apt-get install -y certbot python3-certbot-nginx
+certbot --nginx --redirect -d $DOMAIN --non-interactive --agree-tos -m $EMAIL
+
+systemctl reload nginx


### PR DESCRIPTION
## Summary
- improve production setup script
- automatically update code from GitHub, rebuild, and restart service
- set up a systemd timer for periodic updates
- clarify in README that HTTPS is configured and updates happen automatically

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685e789358248333a5828ad9a600cded