### PR TITLE
Fix variable expansion in nginx config

### DIFF
--- a/scripts/setup_production.sh
+++ b/scripts/setup_production.sh
@@ -111,10 +111,10 @@ server {
     location / {
         proxy_pass http://localhost:3000;
         proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Upgrade \$http_upgrade;
         proxy_set_header Connection 'upgrade';
-        proxy_set_header Host $host;
-        proxy_cache_bypass $http_upgrade;
+        proxy_set_header Host \$host;
+        proxy_cache_bypass \$http_upgrade;
     }
 }
 NGINX


### PR DESCRIPTION
## Summary
- escape the `$http_upgrade` and `$host` variables in the nginx config heredoc
- verified the setup script runs without unbound variable errors

## Testing
- `bash -n scripts/setup_production.sh`
- `bash scripts/setup_production.sh >/tmp/setup.log 2>&1 || true`

------
https://chatgpt.com/codex/tasks/task_e_685e7e36da808333b002d2552b4f54b8