### PR TITLE
Fix setup script domain handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,11 +92,11 @@ repository for updates, pulls the `main` branch, rebuilds and restarts the
 service when changes are detected.
 
 ```bash
-sudo ./scripts/setup_production.sh
+DOMAIN=example.com EMAIL=admin@example.com sudo ./scripts/setup_production.sh
 ```
 
-Edit the `DOMAIN` and `EMAIL` variables inside the script if you want to use a
-different hostname or certificate email address. After the script completes the
+Specify your domain and certificate email via the `DOMAIN` and `EMAIL`
+environment variables when running the script. After it completes the
 application will be available over HTTPS.
 
 ### Codex Environment

--- a/scripts/setup_production.sh
+++ b/scripts/setup_production.sh
@@ -10,8 +10,15 @@ fi
 APP_DIR=/opt/hostex-chat
 REPO_URL="https://github.com/example/hostex-chat.git"
 NODE_VERSION=18
-DOMAIN="hostex-chat-c873d713.ox.ci"
-EMAIL="admin@example.com"
+
+# DOMAIN and EMAIL must be provided via environment variables
+DOMAIN="${DOMAIN:-}"
+EMAIL="${EMAIL:-}"
+
+if [ -z "$DOMAIN" ] || [ -z "$EMAIL" ]; then
+  echo "Usage: DOMAIN=example.com EMAIL=user@example.com sudo $0" >&2
+  exit 1
+fi
 
 # install system packages
 apt-get update


### PR DESCRIPTION
## Summary
- setup script now requires DOMAIN and EMAIL environment variables
- document how to use these variables in README

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685e85b36b94833381ef986045ca3db5