### PR TITLE
Add read/unread backend state tracking

### DIFF
--- a/frontend/src/app/api/read-state/route.ts
+++ b/frontend/src/app/api/read-state/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { listReadState, setReadState } from '@/lib/db'
+
+export const dynamic = 'force-dynamic'
+export const runtime = 'nodejs'
+
+export async function GET() {
+  const data = await listReadState()
+  return NextResponse.json({ readState: data })
+}
+
+export async function POST(req: NextRequest) {
+  const { conversationId, read } = await req.json()
+  if (!conversationId) {
+    return NextResponse.json({ error: 'conversationId required' }, { status: 400 })
+  }
+  await setReadState(conversationId, !!read)
+  return NextResponse.json({ status: 'ok' })
+}

--- a/frontend/src/app/api/webhook/hostex/route.ts
+++ b/frontend/src/app/api/webhook/hostex/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import crypto from 'crypto';
-import { addWebhookEvent } from '@/lib/db';
+import { addWebhookEvent, setReadState } from '@/lib/db';
 import { broadcast } from '@/lib/events';
 
 export const dynamic = 'force-dynamic';
@@ -38,6 +38,7 @@ export async function POST(req: NextRequest) {
     const conversationId =
       payload.conversation_id || payload.data?.conversation_id || payload.data?.conversationId;
     if (conversationId) {
+      await setReadState(conversationId, false);
       const event = await addWebhookEvent({ type, conversationId, payload });
       broadcast({ conversationId, message: event.payload?.data || event.payload });
       console.log('Webhook event processed', { type, conversationId });


### PR DESCRIPTION
## Summary
- create `read_state` table with API to update/fetch status
- update webhook logic to mark conversations unread
- sync ChatApp read state with backend

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685f9a1d481c8333aa8ffb3adc328fbb