### PR TITLE
Improve chat UI transitions

### DIFF
--- a/frontend/src/app/chat/[id]/page.tsx
+++ b/frontend/src/app/chat/[id]/page.tsx
@@ -1,5 +1,3 @@
-import ChatApp from '@/components/ChatApp'
-
 export default function ChatPage() {
-  return <ChatApp />
+  return null
 }

--- a/frontend/src/app/chat/layout.tsx
+++ b/frontend/src/app/chat/layout.tsx
@@ -1,0 +1,6 @@
+'use client'
+import ChatApp from '@/components/ChatApp'
+
+export default function ChatLayout() {
+  return <ChatApp />
+}

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -1,5 +1,3 @@
-import ChatApp from '@/components/ChatApp'
-
 export default function ChatHome() {
-  return <ChatApp />
+  return null
 }

--- a/frontend/src/components/ChatApp.tsx
+++ b/frontend/src/components/ChatApp.tsx
@@ -141,7 +141,7 @@ export default function ChatApp() {
     load()
     const id = setInterval(load, 30000)
     return () => clearInterval(id)
-  }, [selectedId])
+  }, [])
 
   const orderMessages = useCallback((messages?: Message[]) => {
     if (!Array.isArray(messages)) return messages
@@ -416,7 +416,7 @@ export default function ChatApp() {
                     </div>
                     </div>
                   {loadingDetail && (
-                    <div className="absolute inset-0 bg-white/50 dark:bg-gray-900/50 flex items-center justify-center">
+                    <div className="absolute top-2 right-2 text-xs text-gray-500">
                       Loading...
                     </div>
                   )}


### PR DESCRIPTION
## Summary
- keep the `ChatApp` component mounted between conversations via a new layout
- stop reloading the conversation list on every chat switch
- show a small loading indicator instead of a full overlay

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685f9ed27b688333be5889a66e30f81d