### PR TITLE
Improve chat UI and settings management

### DIFF
--- a/frontend/src/app/api/settings/[id]/route.ts
+++ b/frontend/src/app/api/settings/[id]/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getSetting, updateSetting, deleteSetting } from '@/lib/db'
+
+export const dynamic = 'force-dynamic'
+export const runtime = 'nodejs'
+
+export async function GET(_req: NextRequest, { params }: { params: { id: string } }) {
+  const setting = await getSetting(params.id)
+  if (!setting) return NextResponse.json({ error: 'not found' }, { status: 404 })
+  return NextResponse.json({ setting })
+}
+
+export async function PUT(req: NextRequest, { params }: { params: { id: string } }) {
+  const { name, data } = await req.json()
+  if (!name) return NextResponse.json({ error: 'name required' }, { status: 400 })
+  await updateSetting(params.id, name, data || {})
+  return NextResponse.json({ status: 'ok' })
+}
+
+export async function DELETE(_req: NextRequest, { params }: { params: { id: string } }) {
+  await deleteSetting(params.id)
+  return NextResponse.json({ status: 'ok' })
+}

--- a/frontend/src/app/api/settings/route.ts
+++ b/frontend/src/app/api/settings/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { listSettings, addSetting } from '@/lib/db'
+
+export const dynamic = 'force-dynamic'
+export const runtime = 'nodejs'
+
+export async function GET() {
+  const settings = await listSettings()
+  return NextResponse.json({ settings })
+}
+
+export async function POST(req: NextRequest) {
+  const { name, data } = await req.json()
+  if (!name) {
+    return NextResponse.json({ error: 'name required' }, { status: 400 })
+  }
+  const setting = await addSetting(name, data || {})
+  return NextResponse.json({ setting })
+}

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -5,112 +5,176 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 
-interface Model {
+interface Setting {
   id: string;
+  name: string;
+  data: any;
 }
 
-export default function Settings() {
-  const [apiKey, setApiKey] = useState("");
-  const [model, setModel] = useState("gpt-3.5-turbo");
-  const [prompt, setPrompt] = useState("");
-  const [models, setModels] = useState<Model[]>([]);
-  const [theme, setTheme] = useState("system");
-  const [loadingModels, setLoadingModels] = useState(false);
+interface Model { id: string }
+
+export default function SettingsPage() {
+  const [settings, setSettings] = useState<Setting[]>([])
+  const [selected, setSelected] = useState<string | null>(null)
+  const [models, setModels] = useState<Model[]>([])
+  const [loadingModels, setLoadingModels] = useState(false)
+
+  const [name, setName] = useState("")
+  const [apiKey, setApiKey] = useState("")
+  const [model, setModel] = useState("gpt-3.5-turbo")
+  const [prompt, setPrompt] = useState("")
+  const [theme, setTheme] = useState("system")
+  const [autoReply, setAutoReply] = useState(false)
+
+  async function load() {
+    const res = await fetch("/api/settings")
+    const data = await res.json()
+    setSettings(data.settings || [])
+  }
 
   useEffect(() => {
-    const s = JSON.parse(localStorage.getItem("settings") || "{}");
-    setApiKey(s.apiKey || "");
-    setModel(s.model || "gpt-3.5-turbo");
-    setPrompt(s.prompt || "");
-    setTheme(s.theme || "system");
-  }, []);
+    load()
+    const active = localStorage.getItem("activeSettingId")
+    if (active) setSelected(active)
+  }, [])
 
   useEffect(() => {
-    if (!apiKey) return;
-    setLoadingModels(true);
+    if (!selected) {
+      setName("");
+      setApiKey("");
+      setModel("gpt-3.5-turbo");
+      setPrompt("");
+      setTheme("system");
+      setAutoReply(false);
+      return;
+    }
+    const s = settings.find((s) => s.id === selected)
+    if (s) {
+      setName(s.name)
+      setApiKey(s.data.apiKey || "")
+      setModel(s.data.model || "gpt-3.5-turbo")
+      setPrompt(s.data.prompt || "")
+      setTheme(s.data.theme || "system")
+      setAutoReply(!!s.data.autoReply)
+    }
+  }, [selected, settings])
+
+  useEffect(() => {
+    if (!apiKey) return
+    setLoadingModels(true)
     fetch("/api/openai/models", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ apiKey }),
     })
       .then((res) => res.json())
-      .then((data) => {
-        if (Array.isArray(data.data)) {
-          setModels(data.data);
-        }
-      })
-      .finally(() => setLoadingModels(false));
-  }, [apiKey]);
+      .then((data) => Array.isArray(data.data) && setModels(data.data))
+      .finally(() => setLoadingModels(false))
+  }, [apiKey])
 
-  function save() {
-    localStorage.setItem(
-      "settings",
-      JSON.stringify({ apiKey, model, prompt, theme })
-    );
-    if (theme === "dark" || (theme === "system" && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
-      document.documentElement.classList.add('dark');
+  async function save() {
+    const payload = { apiKey, model, prompt, theme, autoReply }
+    if (selected) {
+      await fetch(`/api/settings/${selected}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name, data: payload }),
+      })
     } else {
-      document.documentElement.classList.remove('dark');
+      const res = await fetch("/api/settings", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: name || "Default", data: payload }),
+      })
+      const data = await res.json()
+      setSelected(data.setting.id)
     }
-    alert("Saved");
+    await load()
+    localStorage.setItem("activeSettingId", selected || "")
+    alert("Saved")
   }
 
+  async function remove() {
+    if (!selected) return
+    await fetch(`/api/settings/${selected}`, { method: "DELETE" })
+    setSelected(null)
+    await load()
+  }
+
+  function applyTheme(val: string) {
+    if (val === "dark" || (val === "system" && window.matchMedia("(prefers-color-scheme: dark)").matches)) {
+      document.documentElement.classList.add("dark")
+    } else {
+      document.documentElement.classList.remove("dark")
+    }
+  }
+
+  useEffect(() => {
+    applyTheme(theme)
+  }, [theme])
+
   return (
-    <main className="p-4 space-y-4 max-w-xl mx-auto">
+    <main className="p-4 space-y-4 max-w-2xl mx-auto">
       <div className="flex justify-between border-b pb-2 mb-2">
         <h1 className="text-2xl font-bold">Settings</h1>
-        <Link href="/" className="text-blue-600 underline">
-          Back
-        </Link>
+        <Link href="/" className="text-blue-600 underline">Back</Link>
       </div>
-      <div className="space-y-2">
-        <label className="block">
-          <span className="font-medium">OpenAI API Key</span>
-          <Input
-            type="password"
-            className="mt-1 w-full"
-            value={apiKey}
-            onChange={(e) => setApiKey(e.target.value)}
-          />
-        </label>
-        <label className="block">
-          <span className="font-medium">Model</span>
-          <select
-            className="mt-1 w-full rounded border p-2"
-            value={model}
-            onChange={(e) => setModel(e.target.value)}
-          >
-            {loadingModels && <option>Loading...</option>}
-            {models.map((m) => (
-              <option key={m.id} value={m.id}>
-                {m.id}
-              </option>
-            ))}
-          </select>
-        </label>
-        <label className="block">
-          <span className="font-medium">System Prompt</span>
-          <Textarea
-            className="mt-1 w-full"
-            rows={3}
-            value={prompt}
-            onChange={(e) => setPrompt(e.target.value)}
-          />
-        </label>
-        <label className="block">
-          <span className="font-medium">Theme</span>
-          <select
-            className="mt-1 w-full rounded border p-2"
-            value={theme}
-            onChange={(e) => setTheme(e.target.value)}
-          >
-            <option value="light">Light</option>
-            <option value="dark">Dark</option>
-            <option value="system">System</option>
-          </select>
-        </label>
-        <Button onClick={save}>Save</Button>
+      <div className="flex space-x-4">
+        <div className="w-48 space-y-2">
+          {settings.map((s) => (
+            <Button
+              key={s.id}
+              variant={selected === s.id ? "default" : "secondary"}
+              className="w-full"
+              onClick={() => setSelected(s.id)}
+            >
+              {s.name}
+            </Button>
+          ))}
+          <Button variant="outline" className="w-full" onClick={() => setSelected(null)}>
+            New
+          </Button>
+        </div>
+        <div className="flex-1 space-y-2">
+          <label className="block">
+            <span className="font-medium">Name</span>
+            <Input className="mt-1 w-full" value={name} onChange={(e) => setName(e.target.value)} />
+          </label>
+          <label className="block">
+            <span className="font-medium">OpenAI API Key</span>
+            <Input type="password" className="mt-1 w-full" value={apiKey} onChange={(e) => setApiKey(e.target.value)} />
+          </label>
+          <label className="block">
+            <span className="font-medium">Model</span>
+            <select className="mt-1 w-full rounded border p-2" value={model} onChange={(e) => setModel(e.target.value)}>
+              {loadingModels && <option>Loading...</option>}
+              {models.map((m) => (
+                <option key={m.id} value={m.id}>{m.id}</option>
+              ))}
+            </select>
+          </label>
+          <label className="block">
+            <span className="font-medium">System Prompt</span>
+            <Textarea className="mt-1 w-full" rows={3} value={prompt} onChange={(e) => setPrompt(e.target.value)} />
+          </label>
+          <label className="flex items-center space-x-2">
+            <input type="checkbox" checked={autoReply} onChange={(e) => setAutoReply(e.target.checked)} />
+            <span>Auto generate reply</span>
+          </label>
+          <label className="block">
+            <span className="font-medium">Theme</span>
+            <select className="mt-1 w-full rounded border p-2" value={theme} onChange={(e) => setTheme(e.target.value)}>
+              <option value="light">Light</option>
+              <option value="dark">Dark</option>
+              <option value="system">System</option>
+            </select>
+          </label>
+          <div className="space-x-2">
+            <Button onClick={save}>Save</Button>
+            {selected && <Button variant="destructive" onClick={remove}>Delete</Button>}
+          </div>
+        </div>
       </div>
     </main>
-  );
+  )
 }

--- a/frontend/src/components/ConversationItem.tsx
+++ b/frontend/src/components/ConversationItem.tsx
@@ -51,9 +51,22 @@ function preview(content?: string) {
   return line.length > 50 ? line.slice(0, 50) + '...' : line;
 }
 
-function formatTime(ts?: string) {
-  if (!ts) return '';
-  return new Date(ts).toLocaleString();
+function relativeTime(ts?: string) {
+  if (!ts) return ''
+  const diff = Date.now() - new Date(ts).getTime()
+  const s = Math.floor(diff / 1000)
+  if (s < 60) return `${s}s ago`
+  const m = Math.floor(s / 60)
+  if (m < 60) return `${m}m ago`
+  const h = Math.floor(m / 60)
+  if (h < 24) return `${h}h ago`
+  const d = Math.floor(h / 24)
+  return `${d}d ago`
+}
+
+function needsReply(conv: any) {
+  const last = getLastMessage(conv)
+  return last && last.sender_role !== 'host'
 }
 
 export default function ConversationItem({ conv, selected, hasUpdate, unread, onClick }: Props) {
@@ -62,9 +75,9 @@ export default function ConversationItem({ conv, selected, hasUpdate, unread, on
       <Button
         className={`w-full text-left border p-2 hover:bg-gray-50 dark:hover:bg-gray-800 h-auto ${
           selected
-            ? 'bg-gray-100 dark:bg-gray-800'
+            ? 'bg-gray-200 dark:bg-gray-800'
             : unread
-            ? 'bg-blue-50 dark:bg-gray-700'
+            ? 'bg-blue-100 dark:bg-blue-900'
             : 'dark:bg-gray-700'
         } ${hasUpdate || unread ? 'border-blue-500' : ''} ${hasUpdate ? 'border-blue-800' : ''}`}
         onClick={onClick}
@@ -90,13 +103,16 @@ export default function ConversationItem({ conv, selected, hasUpdate, unread, on
           </div>
           <div className="text-right pl-2">
             <div className="text-xs text-gray-500 whitespace-nowrap">
-              {formatTime(
+              {relativeTime(
                 getLastMessage(conv)?.created_at ||
                 getLastMessage(conv)?.createdAt
               )}
             </div>
             {(hasUpdate || unread) && (
               <span className="ml-2 mt-1 inline-block h-2 w-2 rounded-full bg-blue-500" />
+            )}
+            {needsReply(conv) && (
+              <span className="ml-1 mt-1 inline-block h-2 w-2 rounded-full bg-red-500" title="Reply needed" />
             )}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add settings table and CRUD API
- support multiple setting profiles with auto-reply option
- fetch active settings in chat app and apply theme
- make sidebars resizable and enhance unread styling
- display relative timestamps and highlight conversations that need a reply

## Testing
- `npx tsc --noEmit` *(fails: npm registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685fb8ac4d088333bb89c8e3064f62cd