### PR TITLE
Implement Shadcn separators and tweak chat list

### DIFF
--- a/frontend/src/components/ChatApp.tsx
+++ b/frontend/src/components/ChatApp.tsx
@@ -7,6 +7,7 @@ import ConversationItem from './ConversationItem'
 import MessageBubble, { Message } from './MessageBubble'
 import { Button } from './ui/button'
 import { Textarea } from './ui/textarea'
+import { Separator } from './ui/separator'
 import { Sparkles, Send as SendIcon, FileText } from 'lucide-react'
 
 interface Conversation {
@@ -354,9 +355,9 @@ export default function ChatApp() {
   return (
     <div className="flex-1 flex flex-col overflow-hidden w-full h-full">
       <Header />
-      <main className="flex flex-1 divide-x overflow-hidden h-full">
+      <main className="flex flex-1 overflow-hidden h-full">
         <aside
-          className="w-72 flex flex-col border-r overflow-hidden resize-x"
+          className="w-72 flex flex-col overflow-hidden resize-x"
           style={{ minWidth: '200px', maxWidth: '600px' }}
         >
           {loadingList ? (
@@ -387,6 +388,7 @@ export default function ChatApp() {
             </ul>
           )}
         </aside>
+        <Separator orientation="vertical" />
         <section className="flex-1 flex overflow-hidden">
           <div className="flex-1 flex flex-col overflow-hidden">
             {selectedId ? (
@@ -454,10 +456,12 @@ export default function ChatApp() {
             )}
           </div>
           {detail && (
-            <aside
-              className="hidden w-60 shrink-0 border-l p-4 space-y-4 overflow-y-auto md:block resize-x"
-              style={{ minWidth: '180px', maxWidth: '400px' }}
-            >
+            <>
+              <Separator orientation="vertical" />
+              <aside
+                className="hidden w-60 shrink-0 p-4 space-y-4 overflow-y-auto md:block resize-x"
+                style={{ minWidth: '180px', maxWidth: '400px' }}
+              >
               {detail.customer && (
                 <div>
                   <h2 className="font-semibold mb-1">Customer</h2>
@@ -477,7 +481,8 @@ export default function ChatApp() {
                   <pre className="whitespace-pre-wrap text-xs mt-2">{JSON.stringify(detail.property, null, 2)}</pre>
                 </div>
               )}
-            </aside>
+              </aside>
+            </>
           )}
         </section>
       </main>

--- a/frontend/src/components/ConversationItem.tsx
+++ b/frontend/src/components/ConversationItem.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { Button } from './ui/button'
+import { cn } from '@/lib/utils'
 
 interface Props {
   conv: any;
@@ -12,10 +13,11 @@ interface Props {
 function getCustomerName(conv: any) {
   return (
     conv.customer?.name ||
+    conv.customer?.full_name ||
     conv.customer_name ||
     conv.name ||
     conv.subject ||
-    conv.id
+    'Unknown'
   );
 }
 
@@ -73,13 +75,12 @@ export default function ConversationItem({ conv, selected, hasUpdate, unread, on
   return (
     <li>
       <Button
-        className={`w-full text-left border p-2 hover:bg-gray-50 dark:hover:bg-gray-800 h-auto ${
-          selected
-            ? 'bg-gray-200 dark:bg-gray-800'
-            : unread
-            ? 'bg-blue-100 dark:bg-blue-900'
-            : 'dark:bg-gray-700'
-        } ${hasUpdate || unread ? 'border-blue-500' : ''} ${hasUpdate ? 'border-blue-800' : ''}`}
+        className={cn(
+          'w-full text-left h-auto border',
+          selected ? 'bg-muted' : unread ? 'bg-primary/10' : '',
+          hasUpdate || unread ? 'border-blue-500' : '',
+          hasUpdate ? 'border-blue-800' : ''
+        )}
         onClick={onClick}
         variant="secondary"
         size="default"

--- a/frontend/src/components/ui/separator.tsx
+++ b/frontend/src/components/ui/separator.tsx
@@ -1,0 +1,26 @@
+"use client"
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+export interface SeparatorProps extends React.HTMLAttributes<HTMLDivElement> {
+  orientation?: "horizontal" | "vertical"
+}
+
+const Separator = React.forwardRef<HTMLDivElement, SeparatorProps>(
+  ({ className, orientation = "horizontal", ...props }, ref) => (
+    <div
+      ref={ref}
+      role="separator"
+      aria-orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border",
+        orientation === "vertical" ? "h-full w-px" : "h-px w-full",
+        className
+      )}
+      {...props}
+    />
+  )
+)
+Separator.displayName = "Separator"
+
+export { Separator }


### PR DESCRIPTION
## Summary
- use Shadcn `Separator` component
- show customer name or fallback text in conversation list
- highlight conversation list rows using tokens
- insert separators between panels

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'next')*

------
https://chatgpt.com/codex/tasks/task_e_685fbcc84d848333bb321f34a776ef24