### PR TITLE
Fix read state persistence

### DIFF
--- a/frontend/src/components/ChatApp.tsx
+++ b/frontend/src/components/ChatApp.tsx
@@ -134,7 +134,7 @@ export default function ChatApp() {
             const newLast = (conv.last_message || conv.lastMessage || {}).created_at
             const oldLast = old ? (old.last_message || old.lastMessage || {}).created_at : undefined
             if (!old) {
-              if (!(conv.id in newReads)) newReads[conv.id] = false
+              // don't override read state when first loading conversations
               newUpdates[conv.id] = true
             } else if (newLast && oldLast && new Date(newLast).getTime() > new Date(oldLast).getTime()) {
               if (conv.id !== selectedId) {


### PR DESCRIPTION
## Summary
- prevent overwriting read state when loading conversations

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685fd2dd03a083339e7abaa3cf5b41ff