### PR TITLE
Fix read state persistence and sync via SSE

### DIFF
--- a/frontend/src/app/api/read-state/events/route.ts
+++ b/frontend/src/app/api/read-state/events/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest } from 'next/server'
+import { addReadStateClient, removeReadStateClient } from '@/lib/readStateEvents'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+export async function GET(req: NextRequest) {
+  const { readable, writable } = new TransformStream()
+  const writer = writable.getWriter()
+  const encoder = new TextEncoder()
+
+  const send = (data: any) => {
+    writer.write(encoder.encode(`data: ${JSON.stringify(data)}\n\n`))
+  }
+
+  addReadStateClient(send)
+
+  const keep = setInterval(() => {
+    writer.write(encoder.encode(':keep-alive\n\n'))
+  }, 15000)
+
+  req.signal.addEventListener('abort', () => {
+    clearInterval(keep)
+    removeReadStateClient(send)
+    writer.close()
+  })
+
+  return new Response(readable, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache, no-transform',
+      Connection: 'keep-alive',
+    },
+  })
+}

--- a/frontend/src/app/api/read-state/route.ts
+++ b/frontend/src/app/api/read-state/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { listReadState, setReadState } from '@/lib/db'
+import { broadcastReadState } from '@/lib/readStateEvents'
 
 export const dynamic = 'force-dynamic'
 export const runtime = 'nodejs'
@@ -14,6 +15,8 @@ export async function POST(req: NextRequest) {
   if (!conversationId) {
     return NextResponse.json({ error: 'conversationId required' }, { status: 400 })
   }
-  await setReadState(conversationId, !!read)
+  const val = !!read
+  await setReadState(conversationId, val)
+  broadcastReadState({ conversationId, read: val })
   return NextResponse.json({ status: 'ok' })
 }

--- a/frontend/src/app/api/webhook/hostex/route.ts
+++ b/frontend/src/app/api/webhook/hostex/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import crypto from 'crypto';
 import { addWebhookEvent, setReadState } from '@/lib/db';
 import { broadcast } from '@/lib/events';
+import { broadcastReadState } from '@/lib/readStateEvents';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -39,6 +40,7 @@ export async function POST(req: NextRequest) {
       payload.conversation_id || payload.data?.conversation_id || payload.data?.conversationId;
     if (conversationId) {
       await setReadState(conversationId, false);
+      broadcastReadState({ conversationId, read: false });
       const event = await addWebhookEvent({ type, conversationId, payload });
       broadcast({ conversationId, message: event.payload?.data || event.payload });
       console.log('Webhook event processed', { type, conversationId });

--- a/frontend/src/lib/readStateEvents.ts
+++ b/frontend/src/lib/readStateEvents.ts
@@ -1,0 +1,19 @@
+const clients = new Set<(data: any) => void>();
+
+export function addReadStateClient(fn: (data: any) => void) {
+  clients.add(fn);
+}
+
+export function removeReadStateClient(fn: (data: any) => void) {
+  clients.delete(fn);
+}
+
+export function broadcastReadState(data: any) {
+  for (const fn of Array.from(clients)) {
+    try {
+      fn(data);
+    } catch {
+      clients.delete(fn);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- prevent overwriting read state when loading conversations
- broadcast read state changes through an SSE endpoint
- push read/unread updates from webhook events
- listen for SSE updates in the chat app

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685fd2dd03a083339e7abaa3cf5b41ff