### PR TITLE
Implement read state events using WebSockets

### DIFF
--- a/frontend/pages/api/read-state-events.ts
+++ b/frontend/pages/api/read-state-events.ts
@@ -1,0 +1,42 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { WebSocketServer } from 'ws'
+import { addReadStateWsClient, removeReadStateWsClient } from '@/lib/readStateWs'
+
+type NextApiResponseServerWS = NextApiResponse & {
+  socket: {
+    server: {
+      wssReadState?: WebSocketServer
+      on: (event: string, cb: (...args: any[]) => void) => void
+    }
+  }
+}
+
+export const config = {
+  api: { bodyParser: false },
+}
+
+export default function handler(
+  req: NextApiRequest,
+  res: NextApiResponseServerWS,
+) {
+  const server = res.socket.server
+  if (!server) {
+    res.status(500).end()
+    return
+  }
+
+  if (!server.wssReadState) {
+    const wss = new WebSocketServer({ noServer: true })
+    server.wssReadState = wss
+    server.on('upgrade', (req: any, socket: any, head: any) => {
+      if (req.url === '/api/read-state-events') {
+        wss.handleUpgrade(req, socket, head, (ws) => {
+          addReadStateWsClient(ws)
+          ws.on('close', () => removeReadStateWsClient(ws))
+        })
+      }
+    })
+  }
+
+  res.status(200).end('ready')
+}

--- a/frontend/src/components/ChatApp.tsx
+++ b/frontend/src/components/ChatApp.tsx
@@ -310,10 +310,12 @@ export default function ChatApp() {
   }, [selectedId, fetchDetail])
 
   useEffect(() => {
-    const es = new EventSource('/api/read-state/events')
-    es.onmessage = (e) => {
+    fetch('/api/read-state-events').catch(() => {})
+    const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws'
+    const ws = new WebSocket(`${protocol}://${window.location.host}/api/read-state-events`)
+    ws.onmessage = (e) => {
       try {
-        const data = JSON.parse(e.data)
+        const data = JSON.parse(e.data as string)
         const id = data.conversationId
         if (!id) return
         setReadState((r) => ({ ...r, [id]: !!data.read }))
@@ -328,7 +330,7 @@ export default function ChatApp() {
       } catch {}
     }
     return () => {
-      es.close()
+      ws.close()
     }
   }, [])
 

--- a/frontend/src/lib/readStateEvents.ts
+++ b/frontend/src/lib/readStateEvents.ts
@@ -1,4 +1,6 @@
-const clients = new Set<(data: any) => void>();
+import { broadcastReadStateWs } from './readStateWs'
+
+const clients = new Set<(data: any) => void>()
 
 export function addReadStateClient(fn: (data: any) => void) {
   clients.add(fn);
@@ -9,6 +11,7 @@ export function removeReadStateClient(fn: (data: any) => void) {
 }
 
 export function broadcastReadState(data: any) {
+  broadcastReadStateWs(data)
   for (const fn of Array.from(clients)) {
     try {
       fn(data);

--- a/frontend/src/lib/readStateWs.ts
+++ b/frontend/src/lib/readStateWs.ts
@@ -1,0 +1,22 @@
+import type { WebSocket } from 'ws'
+
+const clients = new Set<WebSocket>()
+
+export function addReadStateWsClient(ws: WebSocket) {
+  clients.add(ws)
+}
+
+export function removeReadStateWsClient(ws: WebSocket) {
+  clients.delete(ws)
+}
+
+export function broadcastReadStateWs(data: any) {
+  const payload = JSON.stringify(data)
+  for (const ws of Array.from(clients)) {
+    if (ws.readyState === ws.OPEN) {
+      ws.send(payload)
+    } else {
+      clients.delete(ws)
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- broadcast read state events over WebSockets
- expose `/api/read-state-events` WebSocket endpoint
- update client to use WebSocket for read state

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685fdde0fe54833395f9cf1bc887c52b