### PR TITLE
Update README database path

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ This project integrates Hostex conversations with ChatGPT, offering a web-based 
    npm run dev
    ```
 
-The application stores data in a SQLite database file named `db.sqlite` in the
-project root. Installing the dependencies will automatically provide the
-required SQLite driver.
+The application stores data in a SQLite database file created in the
+`frontend/` directory as `frontend/db.sqlite` when the server runs. This file is
+already excluded by `.gitignore` inside `frontend/`. Installing the
+dependencies will automatically provide the required SQLite driver.
 
 ## API Routes
 


### PR DESCRIPTION
## Summary
- clarify that `db.sqlite` is created under the `frontend` directory
- mention `.gitignore` already excludes this file

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685fe2f2fbcc833389b3f8f67a6cd8a1