### PR TITLE
Integrate read state into conversation fetch

### DIFF
--- a/frontend/src/app/api/conversations/route.ts
+++ b/frontend/src/app/api/conversations/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { getReadState } from '@/lib/db';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -35,6 +36,22 @@ export async function GET() {
     }
 
     const data = await res.json();
+    const list =
+      data.conversations ||
+      data.items ||
+      data.data?.conversations ||
+      data.data?.items ||
+      data.data ||
+      data;
+
+    if (Array.isArray(list)) {
+      const ids = list.map((c: any) => c.id).filter(Boolean);
+      const reads = await getReadState(ids);
+      list.forEach((c: any) => {
+        c.isRead = !!reads[c.id];
+      });
+    }
+
     return NextResponse.json(data);
   } catch (err: any) {
     return NextResponse.json({ error: err.message }, { status: 500 });

--- a/frontend/src/components/ChatApp.tsx
+++ b/frontend/src/components/ChatApp.tsx
@@ -92,14 +92,6 @@ export default function ChatApp() {
         // ignore parse error
       }
     }
-    fetch('/api/read-state')
-      .then((res) => res.json())
-      .then((data) => {
-        if (data.readState) {
-          setReadState((r) => ({ ...r, ...data.readState }))
-        }
-      })
-      .catch(() => {})
   }, [])
 
   useEffect(() => {
@@ -130,11 +122,13 @@ export default function ChatApp() {
           const newUpdates = { ...updatesRef.current }
           const arr = Array.isArray(list) ? list : []
           arr.forEach((conv: any) => {
+            if (typeof conv.isRead === 'boolean') {
+              newReads[conv.id] = conv.isRead
+            }
             const old = oldMap[conv.id]
             const newLast = (conv.last_message || conv.lastMessage || {}).created_at
             const oldLast = old ? (old.last_message || old.lastMessage || {}).created_at : undefined
             if (!old) {
-              // don't override read state when first loading conversations
               newUpdates[conv.id] = true
             } else if (newLast && oldLast && new Date(newLast).getTime() > new Date(oldLast).getTime()) {
               if (conv.id !== selectedId) {

--- a/frontend/src/lib/db.ts
+++ b/frontend/src/lib/db.ts
@@ -185,6 +185,24 @@ export async function listReadState(): Promise<Record<string, boolean>> {
   return result;
 }
 
+export async function getReadState(
+  conversationIds: string[],
+): Promise<Record<string, boolean>> {
+  if (!conversationIds.length) {
+    return {};
+  }
+  const placeholders = conversationIds.map(() => '?').join(',');
+  const rows = await run(
+    `SELECT conversation_id as conversationId, is_read as isRead FROM read_state WHERE conversation_id IN (${placeholders})`,
+    conversationIds,
+  );
+  const result: Record<string, boolean> = {};
+  for (const r of rows) {
+    result[r.conversationId] = !!r.isRead;
+  }
+  return result;
+}
+
 export async function listSettings(): Promise<Setting[]> {
   const rows = await run(
     `SELECT id, name, data, created_at as createdAt, updated_at as updatedAt FROM settings`


### PR DESCRIPTION
## Summary
- add `getReadState` helper to fetch read flags for specific conversations
- include `isRead` when returning conversations
- consume `isRead` in `ChatApp` and drop extra read state fetch

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685fe324e0608333ab75d2d1077269aa