### PR TITLE
Add webhook worker service

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ dashboard with the following settings:
 Webhook payloads are stored in `db.sqlite` and broadcast to connected clients via
 Server‑Sent Events.
 
+When running the standalone webhook worker (see below) the URL should still
+point to `/api/webhook/hostex` as nginx proxies this path to the worker.
+
 ## Production Deployment
 
 To run Hostex Chat on a public Ubuntu server you can use the helper script in
@@ -92,6 +95,13 @@ domain of `abc.ox.ci` should have `/root/cert/ox.ci.pem` and
 `/root/cert/ox.ci.key`. HTTP traffic is redirected to HTTPS. An additional timer
 checks the GitHub repository for updates, pulls the `main` branch, rebuilds and
 restarts the service when changes are detected.
+
+The script also compiles `scripts/webhook-worker.ts` and installs a
+`hostex-chat-worker.service` which listens on port 3100 for webhook events. Nginx
+forwards `/api/webhook/hostex` to this worker. Ensure `HOSTEX_API_TOKEN` is set
+so requests can be verified. The worker is started automatically but you can
+restart it with `systemctl restart hostex-chat-worker.service` when updating the
+code.
 
 ```bash
 DOMAIN=example.com sudo ./scripts/setup_production.sh

--- a/scripts/webhook-worker.ts
+++ b/scripts/webhook-worker.ts
@@ -1,0 +1,63 @@
+import http from 'http'
+import crypto from 'crypto'
+import { addWebhookEvent, setReadState } from '../frontend/src/lib/db'
+import { broadcastReadState } from '../frontend/src/lib/readStateEvents'
+import { broadcast } from '../frontend/src/lib/events'
+
+const PORT = parseInt(process.env.WEBHOOK_PORT || '3100', 10)
+const TOKEN = process.env.HOSTEX_API_TOKEN
+
+if (!TOKEN) {
+  console.error('HOSTEX_API_TOKEN environment variable not set')
+  process.exit(1)
+}
+
+const server = http.createServer((req, res) => {
+  if (req.method !== 'POST' || req.url !== '/hostex') {
+    res.statusCode = 404
+    return res.end('Not Found')
+  }
+
+  let data = ''
+  req.on('data', chunk => { data += chunk })
+  req.on('end', async () => {
+    const signature = (req.headers['hostex-signature'] || '') as string
+    const expected = crypto.createHmac('sha256', TOKEN).update(data).digest('hex')
+    if (signature !== expected) {
+      console.warn('Invalid webhook signature')
+      res.statusCode = 401
+      return res.end('Invalid signature')
+    }
+
+    let payload: any
+    try {
+      payload = JSON.parse(data)
+    } catch {
+      res.statusCode = 400
+      return res.end('Invalid JSON')
+    }
+
+    const type = payload.type || payload.event
+    if (type === 'message.created' || type === 'message_created') {
+      const conversationId =
+        payload.conversation_id || payload.data?.conversation_id || payload.data?.conversationId
+      if (conversationId) {
+        try {
+          await setReadState(conversationId, false)
+          broadcastReadState({ conversationId, read: false })
+          const event = await addWebhookEvent({ type, conversationId, payload })
+          broadcast({ conversationId, message: event.payload?.data || event.payload })
+          console.log('Processed webhook event', { type, conversationId })
+        } catch (err) {
+          console.error('Failed to store webhook event', err)
+        }
+      }
+    }
+
+    res.end('ok')
+  })
+})
+
+server.listen(PORT, () => {
+  console.log(`Webhook worker listening on http://localhost:${PORT}/hostex`)
+})


### PR DESCRIPTION
## Summary
- add a webhook worker script to handle Hostex webhooks outside of Next.js
- compile the worker and run it via systemd in `setup_production.sh`
- proxy `/api/webhook/hostex` to the worker with nginx
- document webhook worker usage in the README

## Testing
- `npm run build`
- `npx tsc ../scripts/webhook-worker.ts --module commonjs --target es2020 --esModuleInterop --skipLibCheck --outDir ..`

------
https://chatgpt.com/codex/tasks/task_e_685fe5a3fbc48333a0f851f4e07ab714