### PR TITLE
Sync read state from server

### DIFF
--- a/frontend/src/components/ChatApp.tsx
+++ b/frontend/src/components/ChatApp.tsx
@@ -83,20 +83,9 @@ export default function ChatApp() {
     }
   }, [config])
 
-  useEffect(() => {
-    const stored = localStorage.getItem('readState')
-    if (stored) {
-      try {
-        setReadState(JSON.parse(stored))
-      } catch {
-        // ignore parse error
-      }
-    }
-  }, [])
-
-  useEffect(() => {
-    localStorage.setItem('readState', JSON.stringify(readState))
-  }, [readState])
+  // readState is initialized from the server response when loading
+  // conversations. Local updates are kept in memory and persisted via
+  // `/api/read-state` so the state is shared across devices.
 
   useEffect(() => {
     async function load() {


### PR DESCRIPTION
## Summary
- stop loading/saving `readState` from `localStorage`
- rely on `/api/conversations` for initial `isRead` field
- keep local updates in memory and persist via `/api/read-state`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685fe91d6ce88333b9362f9918113cea