### PR TITLE
Store new setting ID on creation

### DIFF
--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -88,6 +88,7 @@ export default function SettingsPage() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ name, data: payload }),
       })
+      localStorage.setItem("activeSettingId", selected)
     } else {
       const res = await fetch("/api/settings", {
         method: "POST",
@@ -95,10 +96,11 @@ export default function SettingsPage() {
         body: JSON.stringify({ name: name || "Default", data: payload }),
       })
       const data = await res.json()
-      setSelected(data.setting.id)
+      const newId = data.setting.id
+      setSelected(newId)
+      localStorage.setItem("activeSettingId", newId)
     }
     await load()
-    localStorage.setItem("activeSettingId", selected || "")
     alert("Saved")
   }
 


### PR DESCRIPTION
## Summary
- store the new setting ID from POST /api/settings

## Testing
- `npm run lint`
- `npm run build` *(fails: collecting build traces)*

------
https://chatgpt.com/codex/tasks/task_e_685ff4edd5688333b7eadad469a17d99