### PR TITLE
Fix API routing in nginx

### DIFF
--- a/nginx/hostex-chat-cloudflare.conf
+++ b/nginx/hostex-chat-cloudflare.conf
@@ -16,8 +16,34 @@ server {
     real_ip_header CF-Connecting-IP;
     include /etc/nginx/cloudflare-real-ip.conf;
 
-    location /api/ {
+    # routes handled by the backend service
+    location ^~ /api/conversations {
         proxy_pass http://localhost:4000/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+    }
+
+    location ^~ /api/read-state {
+        proxy_pass http://localhost:4000/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+    }
+
+    location ^~ /api/events {
+        proxy_pass http://localhost:4000/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+    }
+
+    # remaining API routes are handled by Next.js
+    location /api/ {
+        proxy_pass http://localhost:3000/api/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';

--- a/scripts/setup_full_production.sh
+++ b/scripts/setup_full_production.sh
@@ -226,8 +226,34 @@ server {
     real_ip_header CF-Connecting-IP;
     include /etc/nginx/cloudflare-real-ip.conf;
 
-    location /api/ {
+    # routes handled by the backend service
+    location ^~ /api/conversations {
         proxy_pass http://localhost:4000/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade \$http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host \$host;
+    }
+
+    location ^~ /api/read-state {
+        proxy_pass http://localhost:4000/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade \$http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host \$host;
+    }
+
+    location ^~ /api/events {
+        proxy_pass http://localhost:4000/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade \$http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host \$host;
+    }
+
+    # remaining API routes are handled by Next.js
+    location /api/ {
+        proxy_pass http://localhost:3000/api/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade \$http_upgrade;
         proxy_set_header Connection 'upgrade';

--- a/scripts/setup_local_production.sh
+++ b/scripts/setup_local_production.sh
@@ -189,8 +189,34 @@ server {
     real_ip_header CF-Connecting-IP;
     include /etc/nginx/cloudflare-real-ip.conf;
 
-    location /api/ {
+    # routes handled by the backend service
+    location ^~ /api/conversations {
         proxy_pass http://localhost:4000/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade \$http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host \$host;
+    }
+
+    location ^~ /api/read-state {
+        proxy_pass http://localhost:4000/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade \$http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host \$host;
+    }
+
+    location ^~ /api/events {
+        proxy_pass http://localhost:4000/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade \$http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host \$host;
+    }
+
+    # remaining API routes are handled by Next.js
+    location /api/ {
+        proxy_pass http://localhost:3000/api/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade \$http_upgrade;
         proxy_set_header Connection 'upgrade';


### PR DESCRIPTION
## Summary
- adjust nginx config to send only conversation and read-state routes to the backend
- forward other /api requests to Next.js
- update production setup scripts with the new routing rules

## Testing
- `node tests/runTests.js`

------
https://chatgpt.com/codex/tasks/task_e_6863a6350dac8333b2b80c3d08c44e72