### PR TITLE
Consolidate backend into frontend service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hostex Chat
 
-Hostex Chat integrates Hostex conversations with ChatGPT. The web UI lives in `frontend/` and communicates with a Node.js backend in `backend/`.
+Hostex Chat integrates Hostex conversations with ChatGPT. All server logic now runs inside the Next.js app under `frontend/`, so only one service needs to be started.
 
 ## Quick Start
 
@@ -19,19 +19,14 @@ cp ../frontend/.env.example ../frontend/.env
 # edit frontend/.env and set HOSTEX_API_TOKEN, OPENAI_API_KEY and NEXT_PUBLIC_BACKEND_URL
 ```
 
-3. Start the servers in two terminals:
+3. Start the development server:
 
 ```bash
-# Terminal 1
 cd frontend
 npm run dev
-
-# Terminal 2
-cd backend
-npm start
 ```
 
-Browse <http://localhost:3000> to access the app. The backend stores data in `frontend/db.sqlite`.
+Browse <http://localhost:3000> to access the app. The server stores data in `frontend/db.sqlite`.
 
 ## Production Setup
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,4 +1,4 @@
 HOSTEX_API_TOKEN=your-hostex-token
 HOSTEX_API_BASE=https://api.hostex.io/v3
 OPENAI_API_KEY=your-openai-key
-NEXT_PUBLIC_BACKEND_URL=http://localhost:4000
+NEXT_PUBLIC_BACKEND_URL=http://localhost:3000/api

--- a/frontend/pages/api/conversations/[id].ts
+++ b/frontend/pages/api/conversations/[id].ts
@@ -1,0 +1,10 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { listConversation, listMessages } from '../../../../backend/db.js'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const id = req.query.id as string
+  const conv = await listConversation(id)
+  if (!conv) return res.status(404).json({ error: 'not found' })
+  const messages = await listMessages(id)
+  res.status(200).json({ data: { ...conv, messages } })
+}

--- a/frontend/pages/api/conversations/index.ts
+++ b/frontend/pages/api/conversations/index.ts
@@ -1,0 +1,9 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { listConversations, listReadState } from '../../../../backend/db.js'
+
+export default async function handler(_req: NextApiRequest, res: NextApiResponse) {
+  const list = await listConversations()
+  const reads = await listReadState()
+  list.forEach((c: any) => { c.isRead = !!reads[c.id] })
+  res.status(200).json({ conversations: list })
+}

--- a/frontend/pages/api/events.ts
+++ b/frontend/pages/api/events.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { WebSocketServer } from 'ws'
-import { addClient, removeClient } from '@/lib/events'
+import { addClient, removeClient, broadcast } from '@/lib/events'
+import { startPolling } from '../../../backend/poller.js'
 
 type NextApiResponseServerWS = NextApiResponse & {
   socket: {
@@ -15,11 +16,20 @@ export const config = {
   api: { bodyParser: false }
 }
 
+let pollingStarted = false
+function ensurePolling() {
+  if (!pollingStarted) {
+    startPolling(broadcast)
+    pollingStarted = true
+  }
+}
+
 
 export default function handler(
   req: NextApiRequest,
   res: NextApiResponseServerWS
 ) {
+  ensurePolling()
   const server = res.socket.server
   if (!server) {
     res.status(500).end()

--- a/frontend/pages/api/read-state.ts
+++ b/frontend/pages/api/read-state.ts
@@ -1,0 +1,16 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { listReadState, setReadState } from '../../../backend/db.js'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'GET') {
+    const readState = await listReadState()
+    res.status(200).json({ readState })
+  } else if (req.method === 'POST') {
+    const { conversationId, read } = req.body || {}
+    if (!conversationId) return res.status(400).json({ error: 'conversationId required' })
+    setReadState(conversationId, !!read)
+    res.status(200).json({ status: 'ok' })
+  } else {
+    res.status(405).end()
+  }
+}

--- a/frontend/pages/api/webhook/hostex.ts
+++ b/frontend/pages/api/webhook/hostex.ts
@@ -1,0 +1,54 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import crypto from 'crypto'
+import { addWebhookEvent, setReadState } from '@/lib/db'
+import { broadcastReadState } from '@/lib/readStateEvents'
+import { broadcast } from '@/lib/events'
+
+export const config = {
+  api: { bodyParser: false },
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.status(405).end()
+    return
+  }
+
+  const token = process.env.HOSTEX_API_TOKEN || ''
+  let data = ''
+  for await (const chunk of req) {
+    data += chunk
+  }
+  const signature = (req.headers['hostex-signature'] || '') as string
+  const expected = crypto.createHmac('sha256', token).update(data).digest('hex')
+  if (signature !== expected) {
+    res.statusCode = 401
+    return res.end('Invalid signature')
+  }
+
+  let payload: any
+  try {
+    payload = JSON.parse(data)
+  } catch {
+    res.statusCode = 400
+    return res.end('Invalid JSON')
+  }
+
+  const type = payload.type || payload.event
+  if (type === 'message.created' || type === 'message_created') {
+    const conversationId =
+      payload.conversation_id || payload.data?.conversation_id || payload.data?.conversationId
+    if (conversationId) {
+      try {
+        await setReadState(conversationId, false)
+        broadcastReadState({ conversationId, read: false })
+        const event = await addWebhookEvent({ type, conversationId, payload })
+        broadcast({ conversationId, message: event.payload?.data || event.payload })
+      } catch (err) {
+        console.error('Failed to store webhook event', err)
+      }
+    }
+  }
+
+  res.end('ok')
+}

--- a/scripts/setup_production.sh
+++ b/scripts/setup_production.sh
@@ -42,12 +42,9 @@ fi
 cd "$APP_DIR/frontend"
 npm install
 npm run build
-# compile webhook worker
-cd "$APP_DIR"
-npx tsc scripts/webhook-worker.ts \
-  --module commonjs --target es2020 --esModuleInterop --skipLibCheck \
-  --outDir .
-cd frontend
+cd ../backend
+npm install
+cd ..
 
 # create update script to pull latest code and rebuild
 cat >/usr/local/bin/hostex-chat-update.sh <<'UPDATE'
@@ -63,13 +60,10 @@ if [ "$LOCAL" != "$REMOTE" ]; then
   cd frontend
   npm install
   npm run build
+  cd ../backend
+  npm install
   cd ..
-  npx tsc scripts/webhook-worker.ts \
-    --module commonjs --target es2020 --esModuleInterop --skipLibCheck \
-    --outDir .
-  cd frontend
   systemctl restart hostex-chat.service
-  systemctl restart hostex-chat-worker.service
 fi
 UPDATE
 chmod +x /usr/local/bin/hostex-chat-update.sh
@@ -94,28 +88,6 @@ SERVICE
 
 systemctl daemon-reload
 systemctl enable --now hostex-chat.service
-
-# webhook worker service
-cat >/etc/systemd/system/hostex-chat-worker.service <<WORKER
-[Unit]
-Description=Hostex Chat Webhook Worker
-After=network.target
-
-[Service]
-Type=simple
-User=www-data
-WorkingDirectory=$APP_DIR/frontend
-ExecStart=/usr/bin/node $APP_DIR/scripts/webhook-worker.js
-Restart=always
-Environment=NODE_ENV=production
-Environment=WEBHOOK_PORT=3100
-
-[Install]
-WantedBy=multi-user.target
-WORKER
-
-systemctl daemon-reload
-systemctl enable --now hostex-chat-worker.service
 
 # create systemd unit to update the app periodically
 cat >/etc/systemd/system/hostex-chat-update.service <<UPDATE_SERVICE
@@ -170,11 +142,6 @@ server {
         proxy_cache_bypass \$http_upgrade;
     }
 
-    location = /api/webhook/hostex {
-        proxy_pass http://localhost:3100/hostex;
-        proxy_http_version 1.1;
-        proxy_set_header Host \$host;
-    }
 }
 NGINX
 


### PR DESCRIPTION
## Summary
- implement backend API routes inside Next.js
- start Hostex polling inside websocket handler
- handle webhooks via Next.js route
- streamline production setup scripts to run a single service
- update README and environment examples

## Testing
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_6863ad24ebd08333b4e9f21d9d5e6b10