### PR TITLE
Add backend service support

### DIFF
--- a/hostex-chat-backend.service
+++ b/hostex-chat-backend.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Hostex Chat Backend
+After=network.target
+
+[Service]
+Type=simple
+User=www-data
+WorkingDirectory=/opt/hostex-chat
+EnvironmentFile=/opt/hostex-chat/.env
+ExecStart=/usr/bin/node backend/index.js
+Restart=always
+Environment=NODE_ENV=production
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add `hostex-chat-backend.service` systemd unit
- enable backend service from `setup_full_production.sh`
- proxy backend endpoints through nginx
- restart backend service on code updates

## Testing
- `node tests/runTests.js`

------
https://chatgpt.com/codex/tasks/task_e_6864a823043c83339aedc834c7bb0b43