### PR TITLE
Merge backend and frontend services

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,19 @@ cp .env frontend/.env
 # edit .env and set HOSTEX_API_TOKEN, OPENAI_API_KEY and DOMAIN
 ```
 
-3. Start the backend server:
+3. Start the combined server which runs both frontend and backend on a single port:
+
+```bash
+node server.mjs
+```
+
+4. Alternatively you can start the services separately. First run the backend server:
 
 ```bash
 npm start --prefix backend
 ```
 
-4. In another terminal start the frontend dev server:
+5. In another terminal start the frontend dev server:
 
 ```bash
 npm run dev --prefix frontend
@@ -47,6 +53,7 @@ export DOMAIN=example.com
 sudo ./scripts/setup_full_production.sh
 ```
 The script creates `/opt/hostex-chat/.env` containing these values. Both the frontend and backend services read from this file at startup.
+You can also run them as a single service by starting `server.mjs` from your service manager.
 
 To deploy from the current directory without cloning:
 

--- a/server.mjs
+++ b/server.mjs
@@ -1,0 +1,67 @@
+import { createRequire } from 'module';
+import express from 'express';
+import http from 'http';
+import cors from 'cors';
+import { WebSocketServer } from 'ws';
+import { listConversations, listConversation, listMessages, listReadState, setReadState } from './backend/db.js';
+import { addClient, removeClient, broadcast } from './backend/events.js';
+import { startPolling } from './backend/poller.js';
+
+const require = createRequire(new URL('./frontend/package.json', import.meta.url));
+const next = require('next');
+
+const dev = process.env.NODE_ENV !== 'production';
+const nextApp = next({ dev, dir: './frontend' });
+const handle = nextApp.getRequestHandler();
+
+nextApp.prepare().then(() => {
+  const app = express();
+  app.use(cors());
+  app.use(express.json());
+
+  app.get('/api/conversations', async (_req, res) => {
+    const list = await listConversations();
+    const reads = await listReadState();
+    list.forEach(c => {
+      c.isRead = !!reads[c.id];
+    });
+    res.json({ conversations: list });
+  });
+
+  app.get('/api/conversations/:id', async (req, res) => {
+    const conv = await listConversation(req.params.id);
+    if (!conv) return res.status(404).json({ error: 'not found' });
+    const messages = await listMessages(req.params.id);
+    res.json({ data: { ...conv, messages } });
+  });
+
+  app.get('/api/read-state', async (_req, res) => {
+    res.json({ readState: await listReadState() });
+  });
+
+  app.post('/api/read-state', async (req, res) => {
+    const { conversationId, read } = req.body || {};
+    if (!conversationId) {
+      return res.status(400).json({ error: 'conversationId required' });
+    }
+    setReadState(conversationId, !!read);
+    res.json({ status: 'ok' });
+  });
+
+  app.all('*', (req, res) => handle(req, res));
+
+  const server = http.createServer(app);
+
+  const wss = new WebSocketServer({ server, path: '/api/events' });
+  wss.on('connection', ws => {
+    addClient(ws);
+    ws.on('close', () => removeClient(ws));
+  });
+
+  startPolling(broadcast);
+
+  const port = parseInt(process.env.PORT || '3000', 10);
+  server.listen(port, () => {
+    console.log('Server listening on http://localhost:' + port);
+  });
+});


### PR DESCRIPTION
## Summary
- add `server.mjs` that hosts Next.js and backend APIs together
- document running the combined service in the README

## Testing
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_686664a008ec8333aa481c9810c0e4a4