### PR TITLE
Fix unified server dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,30 @@ cp .env frontend/.env
 # edit .env and set HOSTEX_API_TOKEN, OPENAI_API_KEY and DOMAIN
 ```
 
-3. Start the backend server:
+3. Start the combined server which hosts both the frontend and backend APIs. It
+   reads configuration from `.env` and will run the Next.js development server
+   when `NODE_ENV` is not set to `production`:
+
+```bash
+node server.mjs
+```
+
+    To use a custom port define the `PORT` environment variable before running
+    the file. When deploying you should first build the frontend and then run
+    the server in production mode:
+
+    ```bash
+    npm run build --prefix frontend
+    NODE_ENV=production PORT=4000 node server.mjs
+    ```
+
+4. Alternatively you can start the services separately. First run the backend server:
 
 ```bash
 npm start --prefix backend
 ```
 
-4. In another terminal start the frontend dev server:
+5. In another terminal start the frontend dev server:
 
 ```bash
 npm run dev --prefix frontend
@@ -46,7 +63,15 @@ export OPENAI_API_KEY=sk-xxx
 export DOMAIN=example.com
 sudo ./scripts/setup_full_production.sh
 ```
-The script creates `/opt/hostex-chat/.env` containing these values. Both the frontend and backend services read from this file at startup.
+The script creates `/opt/hostex-chat/.env` containing these values. Both the
+frontend and backend services read from this file at startup.  You can also run
+them as a single service by launching `server.mjs` through your service manager.
+For a `systemd` unit the `ExecStart` line might look like:
+
+```ini
+ExecStart=/usr/bin/node /opt/hostex-chat/server.mjs
+Environment=NODE_ENV=production
+```
 
 To deploy from the current directory without cloning:
 

--- a/server.mjs
+++ b/server.mjs
@@ -1,0 +1,69 @@
+import { createRequire } from 'module';
+import http from 'http';
+import { listConversations, listConversation, listMessages, listReadState, setReadState } from './backend/db.js';
+import { addClient, removeClient, broadcast } from './backend/events.js';
+import { startPolling } from './backend/poller.js';
+
+const requireFrontend = createRequire(new URL('./frontend/package.json', import.meta.url));
+const requireBackend = createRequire(new URL('./backend/package.json', import.meta.url));
+
+const next = requireFrontend('next');
+const express = requireBackend('express');
+const cors = requireBackend('cors');
+const { WebSocketServer } = requireBackend('ws');
+
+const dev = process.env.NODE_ENV !== 'production';
+const nextApp = next({ dev, dir: './frontend' });
+const handle = nextApp.getRequestHandler();
+
+nextApp.prepare().then(() => {
+  const app = express();
+  app.use(cors());
+  app.use(express.json());
+
+  app.get('/api/conversations', async (_req, res) => {
+    const list = await listConversations();
+    const reads = await listReadState();
+    list.forEach(c => {
+      c.isRead = !!reads[c.id];
+    });
+    res.json({ conversations: list });
+  });
+
+  app.get('/api/conversations/:id', async (req, res) => {
+    const conv = await listConversation(req.params.id);
+    if (!conv) return res.status(404).json({ error: 'not found' });
+    const messages = await listMessages(req.params.id);
+    res.json({ data: { ...conv, messages } });
+  });
+
+  app.get('/api/read-state', async (_req, res) => {
+    res.json({ readState: await listReadState() });
+  });
+
+  app.post('/api/read-state', async (req, res) => {
+    const { conversationId, read } = req.body || {};
+    if (!conversationId) {
+      return res.status(400).json({ error: 'conversationId required' });
+    }
+    setReadState(conversationId, !!read);
+    res.json({ status: 'ok' });
+  });
+
+  app.all('*', (req, res) => handle(req, res));
+
+  const server = http.createServer(app);
+
+  const wss = new WebSocketServer({ server, path: '/api/events' });
+  wss.on('connection', ws => {
+    addClient(ws);
+    ws.on('close', () => removeClient(ws));
+  });
+
+  startPolling(broadcast);
+
+  const port = parseInt(process.env.PORT || '3000', 10);
+  server.listen(port, () => {
+    console.log('Server listening on http://localhost:' + port);
+  });
+});


### PR DESCRIPTION
## Summary
- adjust `server.mjs` to load `express`, `cors` and `ws` from backend's `node_modules`

## Testing
- `npm test --prefix frontend`
- `node server.mjs` starts successfully

------
https://chatgpt.com/codex/tasks/task_e_686664a008ec8333aa481c9810c0e4a4