### PR TITLE
Disable webhook signature checks

### DIFF
--- a/frontend/src/app/api/webhook/hostex/route.ts
+++ b/frontend/src/app/api/webhook/hostex/route.ts
@@ -22,10 +22,11 @@ export async function POST(req: NextRequest) {
 
   console.log('Webhook received', { signature, expected, body: rawBody });
 
-  if (signature !== expected) {
-    console.warn('Invalid webhook signature');
-    return NextResponse.json({ error: 'Invalid signature' }, { status: 401 });
-  }
+  // Webhook signature validation disabled
+  // if (signature !== expected) {
+  //   console.warn('Invalid webhook signature');
+  //   return NextResponse.json({ error: 'Invalid signature' }, { status: 401 });
+  // }
 
   let payload: any;
   try {

--- a/scripts/webhook-worker.ts
+++ b/scripts/webhook-worker.ts
@@ -23,11 +23,12 @@ const server = http.createServer((req, res) => {
   req.on('end', async () => {
     const signature = (req.headers['hostex-signature'] || '') as string
     const expected = crypto.createHmac('sha256', TOKEN).update(data).digest('hex')
-    if (signature !== expected) {
-      console.warn('Invalid webhook signature')
-      res.statusCode = 401
-      return res.end('Invalid signature')
-    }
+    // Webhook signature validation disabled
+    // if (signature !== expected) {
+    //   console.warn('Invalid webhook signature')
+    //   res.statusCode = 401
+    //   return res.end('Invalid signature')
+    // }
 
     let payload: any
     try {


### PR DESCRIPTION
## Summary
- stop checking hostex webhook signature in Next.js route
- stop checking signature in webhook worker script

## Testing
- `./scripts/setup_codex.sh`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_68669bb162988333bdb4121fc8e25579