### PR TITLE
Fix unread styling

### DIFF
--- a/frontend/src/components/ConversationItem.tsx
+++ b/frontend/src/components/ConversationItem.tsx
@@ -77,9 +77,9 @@ export default function ConversationItem({ conv, selected, hasUpdate, unread, on
       <Button
         className={cn(
           'w-full text-left h-auto border',
-          selected ? 'bg-muted' : unread ? 'bg-primary/10' : '',
-          hasUpdate || unread ? 'border-blue-500' : '',
-          hasUpdate ? 'border-blue-800' : ''
+          unread && cn('bg-blue-50', !hasUpdate && 'border-blue-500'),
+          hasUpdate && 'border-blue-800',
+          selected && 'bg-muted'
         )}
         onClick={onClick}
         variant="secondary"


### PR DESCRIPTION
## Summary
- simplify unread state styling in ConversationItem

## Testing
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_68677ecff1b883339b16707af2c5221c