### PR TITLE
Add AI endpoint setting

### DIFF
--- a/frontend/src/app/api/conversations/[id]/replies/route.ts
+++ b/frontend/src/app/api/conversations/[id]/replies/route.ts
@@ -10,7 +10,7 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
 }
 
 export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
-  const { messages, model = 'gpt-3.5-turbo', apiKey } = await req.json();
+  const { messages, model = 'gpt-3.5-turbo', apiKey, endpoint } = await req.json();
   const key = apiKey || process.env.OPENAI_API_KEY;
   if (!key) {
     return NextResponse.json({ error: 'OPENAI_API_KEY not configured' }, { status: 500 });
@@ -18,7 +18,8 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
 
   await addOpenAILog({ conversationId: params.id, payload: { model, messages } });
 
-  const res = await fetch('https://api.openai.com/v1/chat/completions', {
+  const base = (endpoint || 'https://api.openai.com/v1').replace(/\/$/, '');
+  const res = await fetch(`${base}/chat/completions`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/frontend/src/app/api/openai/models/route.ts
+++ b/frontend/src/app/api/openai/models/route.ts
@@ -4,11 +4,12 @@ export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
 
 export async function POST(req: NextRequest) {
-  const { apiKey } = await req.json();
+  const { apiKey, endpoint } = await req.json();
   if (!apiKey) {
     return NextResponse.json({ error: 'apiKey required' }, { status: 400 });
   }
-  const res = await fetch('https://api.openai.com/v1/models', {
+  const base = (endpoint || 'https://api.openai.com/v1').replace(/\/$/, '');
+  const res = await fetch(`${base}/models`, {
     headers: {
       Authorization: `Bearer ${apiKey}`,
     },

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -30,6 +30,7 @@ export default function SettingsPage() {
 
   const [name, setName] = useState("")
   const [apiKey, setApiKey] = useState("")
+  const [endpoint, setEndpoint] = useState("https://api.openai.com/v1")
   const [model, setModel] = useState("gpt-3.5-turbo")
   const [prompt, setPrompt] = useState("")
   const [theme, setTheme] = useState("system")
@@ -52,6 +53,7 @@ export default function SettingsPage() {
     if (!selected) {
       setName("");
       setApiKey("");
+      setEndpoint("https://api.openai.com/v1");
       setModel("gpt-3.5-turbo");
       setPrompt("");
       setTheme("system");
@@ -63,6 +65,7 @@ export default function SettingsPage() {
     if (s) {
       setName(s.name)
       setApiKey(s.data.apiKey || "")
+      setEndpoint(s.data.endpoint || "https://api.openai.com/v1")
       setModel(s.data.model || "gpt-3.5-turbo")
       setPrompt(s.data.prompt || "")
       setTheme(s.data.theme || "system")
@@ -81,15 +84,15 @@ export default function SettingsPage() {
     fetch("/api/openai/models", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ apiKey }),
+      body: JSON.stringify({ apiKey, endpoint }),
     })
       .then((res) => res.json())
       .then((data) => Array.isArray(data.data) && setModels(data.data))
       .finally(() => setLoadingModels(false))
-  }, [apiKey])
+  }, [apiKey, endpoint])
 
   async function save() {
-    const payload = { apiKey, model, prompt, theme, autoReply }
+    const payload = { apiKey, model, prompt, theme, autoReply, endpoint }
     let interval = 0
     if (pollValue === "refresh") {
       payload["pollOnRefresh"] = true
@@ -170,6 +173,10 @@ export default function SettingsPage() {
           <label className="block">
             <span className="font-medium">OpenAI API Key</span>
             <Input type="password" className="mt-1 w-full" value={apiKey} onChange={(e) => setApiKey(e.target.value)} />
+          </label>
+          <label className="block">
+            <span className="font-medium">AI Endpoint</span>
+            <Input className="mt-1 w-full" value={endpoint} onChange={(e) => setEndpoint(e.target.value)} />
           </label>
           <label className="block space-y-1">
             <span className="font-medium">Model</span>

--- a/frontend/src/components/ChatApp.tsx
+++ b/frontend/src/components/ChatApp.tsx
@@ -210,6 +210,7 @@ export default function ChatApp() {
     async (msgs: { sender_role?: string; content: string }[]) => {
       const settings = config?.data || {}
       const apiKey = settings.apiKey
+      const endpoint = settings.endpoint || 'https://api.openai.com/v1'
       const model = settings.model || 'gpt-3.5-turbo'
       const prompt = settings.prompt
       const payload = msgs.map((m) => ({
@@ -231,7 +232,7 @@ export default function ChatApp() {
         const res = await fetch(`/api/conversations/${selectedId}/replies`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ messages: payload, model, apiKey }),
+          body: JSON.stringify({ messages: payload, model, apiKey, endpoint }),
         })
         const data = await safeJSON(res)
         if (!res.ok || data.error) {


### PR DESCRIPTION
## Summary
- allow customizing the AI endpoint
- pass endpoint through API routes
- handle endpoint when generating replies

## Testing
- `node tests/runTests.js`

------
https://chatgpt.com/codex/tasks/task_e_68711907466483339459bc8b44a51b89