### PR TITLE
Add dark theme colors for conversation list items

### DIFF
--- a/frontend/src/components/ConversationItem.tsx
+++ b/frontend/src/components/ConversationItem.tsx
@@ -77,7 +77,11 @@ export default function ConversationItem({ conv, selected, hasUpdate, unread, on
       <Button
         className={cn(
           'w-full text-left h-auto border',
-          unread && cn('bg-blue-50', !hasUpdate && 'border-blue-500'),
+          unread &&
+            cn(
+              'bg-blue-50 dark:bg-blue-900',
+              !hasUpdate && 'border-blue-500 dark:border-blue-700'
+            ),
           hasUpdate && 'border-blue-800',
           selected && 'bg-muted'
         )}


### PR DESCRIPTION
## Summary
- tweak conversation item style so blue highlight works in dark mode

## Testing
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_6871235bf5508333948b55c9e402290e