### PR TITLE
Fix generateReply to use fresh settings

### DIFF
--- a/frontend/src/components/ChatApp.tsx
+++ b/frontend/src/components/ChatApp.tsx
@@ -246,7 +246,7 @@ export default function ChatApp() {
         setGenerating(false)
       }
     },
-    [selectedId]
+    [selectedId, config]
   )
 
   const fetchDetail = useCallback(


### PR DESCRIPTION
## Summary
- refresh reply generator when config changes so saved settings apply

## Testing
- `./scripts/setup_codex.sh`
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_68712f5f60fc833386bbc8f436cfecbd