### PR TITLE
Use sonner toast for settings save

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,6 +1,7 @@
 'use client';
 import '@/styles/globals.css';
 import { ReactNode, useEffect } from 'react';
+import { Toaster } from '@/components/ui/sonner';
 
 function applyTheme(theme: string) {
   const systemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
@@ -26,6 +27,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en" className="h-full">
       <body className="min-h-screen bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100 flex flex-col h-full">
+        <Toaster />
         {children}
       </body>
     </html>

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import { toast } from "sonner";
 import {
   Select,
   SelectContent,
@@ -102,26 +103,35 @@ export default function SettingsPage() {
       interval = parseInt(pollValue) || 0
       payload["pollOnRefresh"] = false
     }
-    if (selected) {
-      await fetch(`/api/settings/${selected}`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name, data: payload, pollInterval: interval }),
-      })
-      localStorage.setItem("activeSettingId", selected)
-    } else {
-      const res = await fetch("/api/settings", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name: name || "Default", data: payload, pollInterval: interval }),
-      })
-      const data = await res.json()
-      const newId = data.setting.id
-      setSelected(newId)
-      localStorage.setItem("activeSettingId", newId)
+    try {
+      let res: Response
+      if (selected) {
+        res = await fetch(`/api/settings/${selected}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name, data: payload, pollInterval: interval }),
+        })
+        localStorage.setItem("activeSettingId", selected)
+      } else {
+        res = await fetch("/api/settings", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name: name || "Default", data: payload, pollInterval: interval }),
+        })
+        if (res.ok) {
+          const data = await res.json()
+          const newId = data.setting.id
+          setSelected(newId)
+          localStorage.setItem("activeSettingId", newId)
+        }
+      }
+      if (!res.ok) throw new Error("Failed")
+      await load()
+      toast.success("Saved")
+    } catch (err) {
+      console.error(err)
+      toast.error("Failed to save")
     }
-    await load()
-    alert("Saved")
   }
 
   async function remove() {


### PR DESCRIPTION
## Summary
- enable global toast notifications via `Toaster`
- use `sonner` to display success/error toast on saving settings

## Testing
- `npm run test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_68712f6cb5808333b64295643ecfd0f5