### PR TITLE
Fix webhook proxy path

### DIFF
--- a/nginx/hostex-chat-cloudflare.conf
+++ b/nginx/hostex-chat-cloudflare.conf
@@ -60,7 +60,8 @@ server {
     }
 
     location = /api/webhook/hostex {
-        proxy_pass http://localhost:3100/hostex;
+        # handled by the Next.js API route
+        proxy_pass http://localhost:3000;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
     }


### PR DESCRIPTION
## Summary
- use main Node port in nginx config for webhook

## Testing
- `node tests/runTests.js`

------
https://chatgpt.com/codex/tasks/task_e_687133a1c958833391645c2a748c264c