### PR TITLE
Persist UI filters and simplify chat badges

### DIFF
--- a/frontend/src/components/ChatApp.tsx
+++ b/frontend/src/components/ChatApp.tsx
@@ -58,6 +58,25 @@ export default function ChatApp() {
   const [sortDesc, setSortDesc] = useState(true)
   const [showUnreadOnly, setShowUnreadOnly] = useState(false)
   const [isLoadingReadState, setIsLoadingReadState] = useState(true)
+
+  // load persisted filter settings
+  useEffect(() => {
+    try {
+      const saved = sessionStorage.getItem('chatFilters')
+      if (saved) {
+        const f = JSON.parse(saved)
+        if (typeof f.showUnreadOnly === 'boolean') setShowUnreadOnly(f.showUnreadOnly)
+        if (typeof f.sortDesc === 'boolean') setSortDesc(f.sortDesc)
+      }
+    } catch {}
+  }, [])
+
+  // persist filter settings
+  useEffect(() => {
+    try {
+      sessionStorage.setItem('chatFilters', JSON.stringify({ showUnreadOnly, sortDesc }))
+    } catch {}
+  }, [showUnreadOnly, sortDesc])
   const readRef = useRef(readState)
   const updateServerRead = useCallback(async (id: string, val: boolean) => {
     try {
@@ -439,7 +458,6 @@ export default function ChatApp() {
                     key={conv.id}
                     conv={conv}
                     selected={selectedId === conv.id}
-                    hasUpdate={updates[conv.id]}
                     unread={
                       readState[conv.id] !== undefined
                         ? !readState[conv.id]

--- a/frontend/src/components/ConversationItem.tsx
+++ b/frontend/src/components/ConversationItem.tsx
@@ -5,7 +5,6 @@ import { cn } from '@/lib/utils'
 interface Props {
   conv: any;
   selected?: boolean;
-  hasUpdate?: boolean;
   unread?: boolean;
   onClick: () => void;
 }
@@ -66,23 +65,14 @@ function relativeTime(ts?: string) {
   return `${d}d ago`
 }
 
-function needsReply(conv: any) {
-  const last = getLastMessage(conv)
-  return last && last.sender_role !== 'host'
-}
 
-export default function ConversationItem({ conv, selected, hasUpdate, unread, onClick }: Props) {
+export default function ConversationItem({ conv, selected, unread, onClick }: Props) {
   return (
     <li>
       <Button
         className={cn(
           'w-full text-left h-auto border',
-          unread &&
-            cn(
-              'bg-blue-50 dark:bg-blue-900',
-              !hasUpdate && 'border-blue-500 dark:border-blue-700'
-            ),
-          hasUpdate && 'border-blue-800',
+          unread && 'bg-blue-50 dark:bg-blue-900 border-blue-500 dark:border-blue-700',
           selected && 'bg-muted'
         )}
         onClick={onClick}
@@ -113,11 +103,8 @@ export default function ConversationItem({ conv, selected, hasUpdate, unread, on
                 getLastMessage(conv)?.createdAt
               )}
             </div>
-            {(hasUpdate || unread) && (
+            {unread && (
               <span className="ml-2 mt-1 inline-block h-2 w-2 rounded-full bg-blue-500" />
-            )}
-            {needsReply(conv) && (
-              <span className="ml-1 mt-1 inline-block h-2 w-2 rounded-full bg-red-500" title="Reply needed" />
             )}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- persist chat filter settings in session storage
- show unread indicator only for unread messages

## Testing
- `node tests/runTests.js`

------
https://chatgpt.com/codex/tasks/task_e_687134287d4c8333b6d4467247e0f980